### PR TITLE
Add gh CLI via shared install script in scripts/

### DIFF
--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -18,6 +18,9 @@ RUN groupadd --gid $USER_GID $USERNAME \
 RUN mkdir -p /home/$USERNAME/.claude && \
     chown -R $USERNAME:$USERNAME /home/$USERNAME/.claude
 
+COPY scripts/install-gh.sh /tmp/install-gh.sh
+RUN chmod +x /tmp/install-gh.sh && /tmp/install-gh.sh
+
 USER $USERNAME
 
 RUN git config --global --add safe.directory /opt/esp/idf/components/openthread/openthread

--- a/.devcontainer/docs/Dockerfile
+++ b/.devcontainer/docs/Dockerfile
@@ -23,6 +23,9 @@ RUN groupadd --gid $USER_GID $USERNAME \
 RUN mkdir -p /home/$USERNAME/.claude && \
     chown -R $USERNAME:$USERNAME /home/$USERNAME/.claude
 
+COPY scripts/install-gh.sh /tmp/install-gh.sh
+RUN chmod +x /tmp/install-gh.sh && /tmp/install-gh.sh
+
 USER $USERNAME
 
 RUN curl -fsSL https://claude.ai/install.sh | bash -s stable

--- a/.devcontainer/js/Dockerfile
+++ b/.devcontainer/js/Dockerfile
@@ -19,6 +19,9 @@ RUN userdel -r node \
 RUN mkdir -p /home/$USERNAME/.claude && \
     chown -R $USERNAME:$USERNAME /home/$USERNAME/.claude
 
+COPY scripts/install-gh.sh /tmp/install-gh.sh
+RUN chmod +x /tmp/install-gh.sh && /tmp/install-gh.sh
+
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright
 
 COPY ./web/package.json ./web/package-lock.json /tmp/web/

--- a/.devcontainer/python/Dockerfile
+++ b/.devcontainer/python/Dockerfile
@@ -23,6 +23,9 @@ ARG USER_GID=$USER_UID
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID --create-home --shell /bin/bash $USERNAME
 
+COPY scripts/install-gh.sh /tmp/install-gh.sh
+RUN chmod +x /tmp/install-gh.sh && /tmp/install-gh.sh
+
 USER $USERNAME
 
 RUN python3 -m venv /home/$USERNAME/venv

--- a/scripts/dump_env.sh
+++ b/scripts/dump_env.sh
@@ -21,6 +21,8 @@ ENV_MAP[STREAM_CLIENT_URI]="${ENV_MAP[ESP32_ADDRESS]}/stream"
 
 ENV_MAP[OTEL_EXPORTER_OTLP_ENDPOINT]=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://jaeger:4318}
 
+ENV_MAP[GH_TOKEN]=${GH_TOKEN:-}
+
 # Iterate all env entries by sorted key so .env output is deterministic.
 while IFS= read -r key; do
 	printf '%s=%s\n' "$key" "${ENV_MAP[$key]}" >> .env.tmp

--- a/scripts/install-gh.sh
+++ b/scripts/install-gh.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Install gh CLI following the official Debian installation method:
+# https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian
+
+(type -p wget >/dev/null || (apt-get update && apt-get install wget -y)) \
+&& mkdir -p -m 755 /etc/apt/keyrings \
+        && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        && cat $out | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+&& chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+&& apt-get update \
+&& apt-get install gh -y


### PR DESCRIPTION
Creates `scripts/install-gh.sh` following the official Debian installation method and updates all four devcontainer Dockerfiles to use it.

Closes #37

Generated with [Claude Code](https://claude.ai/code)