### PR TITLE
Add Claude Code project-level settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "advisorModel": "claude-opus-4-7",
+  "permissions": {
+    "defaultMode": "bypassPermissions"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with Opus as the advisor model and `bypassPermissions` as the default permission mode
- Removes the `scripts/claude.sh` wrapper script it replaces

## Why

Using a project-level settings file means any devcontainer that mounts this repo gets the correct Claude Code defaults automatically, without manual setup or a wrapper script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)