### PR TITLE
Add ccache to C++ devcontainer for faster firmware builds

### DIFF
--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -2,8 +2,11 @@ FROM espressif/idf:release-v5.3
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
+    ccache \
     curl \
     locales
+
+ENV IDF_CCACHE_ENABLE=1
 
 # WA for VSCode issue https://github.com/microsoft/vscode/issues/189924
 RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen


### PR DESCRIPTION
Installs ccache and sets IDF_CCACHE_ENABLE=1 in the C++ devcontainer so every idf.py build invocation uses the compiler cache automatically, both locally and in CI.

Closes #45. See #44 for the remaining CI persistence step (#046).

Generated with [Claude Code](https://claude.ai/code)