### PR TITLE
Persist ccache directory across devcontainer rebuilds

### DIFF
--- a/.devcontainer/cpp/devcontainer.json
+++ b/.devcontainer/cpp/devcontainer.json
@@ -6,7 +6,8 @@
     "service": "app",
     "workspaceFolder": "/workspaces/dust-mite",
     "mounts": [
-        "source=claude-code-config,target=/home/vscode/.claude,type=volume"
+        "source=claude-code-config,target=/home/vscode/.claude,type=volume",
+        "source=ccache,target=/home/vscode/.ccache,type=volume"
     ],
     "containerEnv": {
         "PRE_COMMIT_SCRIPT": "${containerWorkspaceFolder}/car/scripts/pre-commit.sh",


### PR DESCRIPTION
Adds a named Docker volume for the ccache directory so the compiler cache survives container rebuilds during local development.

Without this, the cache built during a session is lost on every `Rebuild Container`, negating the benefit of ccache for iterative development.

Closes #45

🤖 Generated with [Claude Code](https://claude.ai/code)