### PR TITLE
Mount host gh config into all devcontainers

### DIFF
--- a/.devcontainer/cpp/devcontainer.json
+++ b/.devcontainer/cpp/devcontainer.json
@@ -7,7 +7,8 @@
     "workspaceFolder": "/workspaces/dust-mite",
     "mounts": [
         "source=claude-code-config,target=/home/vscode/.claude,type=volume",
-        "source=ccache,target=/home/vscode/.ccache,type=volume"
+        "source=ccache,target=/home/vscode/.ccache,type=volume",
+        "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind,consistency=cached"
     ],
     "containerEnv": {
         "PRE_COMMIT_SCRIPT": "${containerWorkspaceFolder}/car/scripts/pre-commit.sh",

--- a/.devcontainer/docs/devcontainer.json
+++ b/.devcontainer/docs/devcontainer.json
@@ -4,7 +4,8 @@
     "service": "app",
     "workspaceFolder": "/workspaces/dust-mite",
     "mounts": [
-        "source=claude-code-config,target=/home/vscode/.claude,type=volume"
+        "source=claude-code-config,target=/home/vscode/.claude,type=volume",
+        "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind,consistency=cached"
     ],
     "containerEnv": {
         "CLAUDE_CONFIG_DIR": "/home/vscode/.claude"

--- a/.devcontainer/js/devcontainer.json
+++ b/.devcontainer/js/devcontainer.json
@@ -6,7 +6,8 @@
     "service": "app",
     "workspaceFolder": "/workspaces/dust-mite",
     "mounts": [
-        "source=claude-code-config,target=/home/vscode/.claude,type=volume"
+        "source=claude-code-config,target=/home/vscode/.claude,type=volume",
+        "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind,consistency=cached"
     ],
     "containerEnv": {
         "PRE_COMMIT_SCRIPT": "${containerWorkspaceFolder}/web/scripts/pre-commit.sh",

--- a/.devcontainer/python/devcontainer.json
+++ b/.devcontainer/python/devcontainer.json
@@ -6,7 +6,8 @@
     "service": "app",
     "workspaceFolder": "/workspaces/dust-mite",
     "mounts": [
-        "source=claude-code-config,target=/home/vscode/.claude,type=volume"
+        "source=claude-code-config,target=/home/vscode/.claude,type=volume",
+        "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind,consistency=cached"
     ],
     // Need to "activate" venv in VSCode because of https://github.com/microsoft/vscode-python/issues/10165
     "remoteEnv": {


### PR DESCRIPTION
## Summary

- Adds `~/.config/gh` bind mount to all four devcontainers (cpp, js, python, docs)
- The `gh` CLI inside each container now uses host credentials automatically, without requiring a separate `gh auth login` step
- Matches the pattern already in use in the `esp-opentelemetry-cpp` sub-repo devcontainer

## Prerequisite

Run `gh auth login` on the host before building or rebuilding the devcontainer. Container creation will fail if `~/.config/gh` does not exist on the host.

## Test plan

- [ ] Rebuild one devcontainer after the change
- [ ] Verify `gh auth status` reports authenticated inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)