### PR TITLE
Fix ccache never being saved in container CI job

### DIFF
--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -7,8 +7,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     locales \
     protobuf-compiler
 
-ENV IDF_CCACHE_ENABLE=1
-
 # WA for VSCode issue https://github.com/microsoft/vscode/issues/189924
 RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen
 
@@ -18,6 +16,9 @@ ARG USER_GID=$USER_UID
 
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID --create-home --shell /bin/bash $USERNAME
+
+ENV IDF_CCACHE_ENABLE=1
+ENV CCACHE_DIR=/home/${USERNAME}/.ccache
 
 RUN mkdir -p /home/$USERNAME/.claude && \
     chown -R $USERNAME:$USERNAME /home/$USERNAME/.claude

--- a/.github/workflows/cpp-car.yml
+++ b/.github/workflows/cpp-car.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Cache ccache
       uses: actions/cache@v5
       with:
-        path: ~/.ccache
+        path: ${{ github.workspace }}/.ccache
         key: ccache-${{ runner.os }}-idf-${{ hashFiles('.devcontainer/cpp/Dockerfile') }}
         restore-keys: |
           ccache-${{ runner.os }}-idf-
@@ -72,8 +72,12 @@ jobs:
         echo "$PATH" >> $GITHUB_PATH
 
     - name: Build
+      env:
+        CCACHE_DIR: ${{ github.workspace }}/.ccache
       run: idf.py build
 
     - name: Build tests
+      env:
+        CCACHE_DIR: ${{ github.workspace }}/.ccache
       run: idf.py build
       working-directory: ./car/test


### PR DESCRIPTION
## Summary

Same root cause as ltowarek/esp-opentelemetry-cpp#49:

- `actions/cache` POST step runs on the **host runner** after the container is stopped
- At that point `~` expands to `/home/runner` (host home), but ccache ran inside the container and wrote to `/github/home/.ccache` — a completely different path
- The cache path was always empty at save time, so no cache entry was ever uploaded

The fix is to use `${{ github.workspace }}/.ccache` for both the cache `path` and `CCACHE_DIR`. The workspace directory is bind-mounted, so it resolves to the same physical path inside the container and on the host when the post step saves the cache.

Also includes the `ENV CCACHE_DIR` devcontainer Dockerfile change from the previous commit.

## Test plan

- [ ] Verify the CI run for this PR shows a cache save step completing successfully
- [ ] On a second run, verify `Cache restored from key: ccache-Linux-idf-...` appears
- [ ] Confirm build time decreases on the second run

🤖 Generated with [Claude Code](https://claude.com/claude-code)