### PR TITLE
Use run_id in ccache key to prevent concurrent save conflicts

### DIFF
--- a/.github/workflows/cpp-car.yml
+++ b/.github/workflows/cpp-car.yml
@@ -62,7 +62,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ${{ github.workspace }}/.ccache
-        key: ccache-${{ runner.os }}-idf-${{ hashFiles('.devcontainer/cpp/Dockerfile') }}
+        key: ccache-${{ runner.os }}-idf-${{ github.run_id }}
         restore-keys: |
           ccache-${{ runner.os }}-idf-
 


### PR DESCRIPTION
## Summary

- The Dockerfile-hash key is identical across all concurrent PRs, causing "Unable to reserve cache" races when two runs try to save the same key
- Using `github.run_id` makes the primary key unique per run so saves never collide
- `restore-keys` still warm up from the most recently saved cache on subsequent runs

## Test plan

- [ ] Verify no "Unable to reserve cache" warnings with concurrent PR runs
- [ ] Verify cache is restored on a second run (`Cache restored from key: ccache-Linux-idf-...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)