### PR TITLE
Fix ccache permission denied on fresh devcontainer volumes

### DIFF
--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -23,6 +23,9 @@ ENV CCACHE_DIR=/home/${USERNAME}/.ccache
 RUN mkdir -p /home/$USERNAME/.claude && \
     chown -R $USERNAME:$USERNAME /home/$USERNAME/.claude
 
+RUN mkdir -p /home/$USERNAME/.ccache && \
+    chown -R $USERNAME:$USERNAME /home/$USERNAME/.ccache
+
 COPY scripts/install-gh.sh /tmp/install-gh.sh
 RUN chmod +x /tmp/install-gh.sh && /tmp/install-gh.sh
 


### PR DESCRIPTION
## Summary

- Pre-create `/home/vscode/.ccache` with correct ownership (`vscode:vscode`) in the C++ devcontainer Dockerfile, using the same `mkdir -p` + `chown` pattern already applied to `.claude`

## Motivation

Docker initialises named volumes with `root:root` ownership on the mount-point directory. When the `ccache` volume is mounted for the first time, Docker copies the image layer at that path into the empty volume — preserving file ownership. Without the pre-created directory in the image, the volume is initialised as root-owned and the `vscode` user gets `Permission denied` when ccache tries to create its `tmp/` subdirectory.

## Test plan

- [ ] Delete the existing `ccache` Docker volume (`docker volume rm ccache`) and reopen the devcontainer
- [ ] Run `idf.py build` — ccache should operate without permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)