### PR TITLE
Temporary ccache stats probe (issue #56)

### DIFF
--- a/.github/workflows/cpp-car.yml
+++ b/.github/workflows/cpp-car.yml
@@ -47,6 +47,9 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+
     defaults:
       run:
         shell: bash
@@ -71,13 +74,15 @@ jobs:
         source $IDF_PATH/export.sh
         echo "$PATH" >> $GITHUB_PATH
 
+    - name: Reset ccache stats
+      run: ccache --zero-stats
+
     - name: Build
-      env:
-        CCACHE_DIR: ${{ github.workspace }}/.ccache
       run: idf.py build
 
     - name: Build tests
-      env:
-        CCACHE_DIR: ${{ github.workspace }}/.ccache
       run: idf.py build
       working-directory: ./car/test
+
+    - name: Print ccache stats
+      run: ccache --show-stats


### PR DESCRIPTION
## Summary

Temporary diagnostic PR for issue #56 — adds `ccache --zero-stats` before builds and `ccache --show-stats` after to measure actual CI hit rates.

**This PR will not be merged.** Close it once the stats from CI logs answer the question.

## Changes

- Hoisted `CCACHE_DIR` to job-level `env:` (removes per-step repetition)
- Added `Reset ccache stats` step before builds (`ccache --zero-stats`)
- Added `Print ccache stats` step after builds (`ccache --show-stats`)

## What to check

In the `Print ccache stats` step of the CI run:
- **> 80% hit rate** → ccache is working well, close issue #56
- **0–20% hit rate** → something prevents cache reuse, investigate
- **0 total calls** → `IDF_CCACHE_ENABLE=1` not reaching the container

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)