### PR TITLE
Run dev/build containers as the host UID/GID via .env

### DIFF
--- a/.devcontainer/cpp/docker-compose.yml
+++ b/.devcontainer/cpp/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     build:
       context: ../..
       dockerfile: .devcontainer/cpp/Dockerfile
-      # Bake the image user as the host UID/GID (from .env) so its home dir,
-      # ccache and the bind-mounted workspace/build are all writable; 1050 default.
       args:
         USER_UID: "${UID:-1050}"
         USER_GID: "${GID:-1050}"
@@ -18,8 +16,8 @@ services:
     env_file:
       - path: ../../.env
     # Uncomment to pass through ESP32 device.
-    devices:
-      - /dev/ttyACM0:/dev/ttyACM0
+    # devices:
+    #   - /dev/ttyACM0:/dev/ttyACM0
     command: sleep infinity
     networks:
       - dust-mite-observability

--- a/.devcontainer/cpp/docker-compose.yml
+++ b/.devcontainer/cpp/docker-compose.yml
@@ -7,13 +7,19 @@ services:
     build:
       context: ../..
       dockerfile: .devcontainer/cpp/Dockerfile
+      # Bake the image user as the host UID/GID (from .env) so its home dir,
+      # ccache and the bind-mounted workspace/build are all writable; 1050 default.
+      args:
+        USER_UID: "${UID:-1050}"
+        USER_GID: "${GID:-1050}"
+    user: "${UID:-1050}:${GID:-1050}"
     volumes:
       - ../..:/workspaces/dust-mite:cached
     env_file:
       - path: ../../.env
     # Uncomment to pass through ESP32 device.
-    # devices:
-    #   - /dev/ttyACM0:/dev/ttyACM0
+    devices:
+      - /dev/ttyACM0:/dev/ttyACM0
     command: sleep infinity
     networks:
       - dust-mite-observability

--- a/.devcontainer/js/docker-compose.yml
+++ b/.devcontainer/js/docker-compose.yml
@@ -7,6 +7,12 @@ services:
     build:
       context: ../..
       dockerfile: .devcontainer/js/Dockerfile
+      # Bake the image user as the host UID/GID (from .env) so the bind-mounted
+      # workspace and caches stay writable; 1050 default for portability.
+      args:
+        USER_UID: "${UID:-1050}"
+        USER_GID: "${GID:-1050}"
+    user: "${UID:-1050}:${GID:-1050}"
     volumes:
       - ../..:/workspaces/dust-mite:cached
     env_file:

--- a/.devcontainer/js/docker-compose.yml
+++ b/.devcontainer/js/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     build:
       context: ../..
       dockerfile: .devcontainer/js/Dockerfile
-      # Bake the image user as the host UID/GID (from .env) so the bind-mounted
-      # workspace and caches stay writable; 1050 default for portability.
       args:
         USER_UID: "${UID:-1050}"
         USER_GID: "${GID:-1050}"

--- a/.devcontainer/python/docker-compose.yml
+++ b/.devcontainer/python/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     build:
       context: ../..
       dockerfile: .devcontainer/python/Dockerfile
-      # Bake the image user as the host UID/GID (from .env) so the bind-mounted
-      # workspace and caches stay writable; 1050 default for portability.
       args:
         USER_UID: "${UID:-1050}"
         USER_GID: "${GID:-1050}"

--- a/.devcontainer/python/docker-compose.yml
+++ b/.devcontainer/python/docker-compose.yml
@@ -7,6 +7,12 @@ services:
     build:
       context: ../..
       dockerfile: .devcontainer/python/Dockerfile
+      # Bake the image user as the host UID/GID (from .env) so the bind-mounted
+      # workspace and caches stay writable; 1050 default for portability.
+      args:
+        USER_UID: "${UID:-1050}"
+        USER_GID: "${GID:-1050}"
+    user: "${UID:-1050}:${GID:-1050}"
     volumes:
       - ../..:/workspaces/dust-mite:cached
     env_file:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,14 +70,15 @@ All environment variables used anywhere in the project must be declared in [scri
 
 ## Starting Devcontainers
 
-For VS Code Dev Container workflow see [CONTRIBUTING.md#development-environment](CONTRIBUTING.md#development-environment). For headless/agent use, the devcontainer images are not started by default. Start them on demand:
+For VS Code Dev Container workflow see [CONTRIBUTING.md#development-environment](CONTRIBUTING.md#development-environment). For headless/agent use, the devcontainer images are not started by default. Start them on demand, always passing `--env-file .env`:
 
 ```bash
-docker compose -f .devcontainer/python/docker-compose.yml up -d --build python
-docker compose -f .devcontainer/js/docker-compose.yml up -d --build js
+docker compose --env-file .env -f .devcontainer/cpp/docker-compose.yml up -d --build cpp
+docker compose --env-file .env -f .devcontainer/python/docker-compose.yml up -d --build python
+docker compose --env-file .env -f .devcontainer/js/docker-compose.yml up -d --build js
 ```
 
-The C++ devcontainer runs as `vscode` uid 1000, while Python and JS run as `vscode` uid 1050. Because all containers share the same bind-mounted workspace, files created by one container cannot be written to by another. If the Python or JS checks fail with permission errors on `.ruff_cache`, `.mypy_cache`, `node_modules`, or `dist`, fix ownership for those paths only — do not chown the whole workspace as that breaks `.git` access for the C++ container and the host: `docker exec -u root <container> bash -c "chown -R vscode:vscode /workspaces/dust-mite/controller /workspaces/dust-mite/web"`.
+`--env-file .env` supplies `UID`/`GID` (written by [scripts/dump_env.sh](scripts/dump_env.sh)) to the `build.args` and `user:` in each devcontainer compose, so the container is built and run as the **host user**. All dev/build/check containers then share the host uid and the bind-mounted workspace, `build/`, and caches stay writable — no `chown` workarounds needed. (Without `.env`, the images fall back to uid `1050` and stay portable.)
 
 ## Running Pre-commit Checks
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     env_file:
       - path: .env
     # Uncomment to pass through ESP32 device.
-    devices:
-      - /dev/ttyACM0:/dev/ttyACM0
+    # devices:
+    #   - /dev/ttyACM0:/dev/ttyACM0
     command: sleep infinity
     networks:
       - dust-mite-observability
@@ -67,8 +67,6 @@ services:
     build:
       context: .
       dockerfile: .devcontainer/js/Dockerfile
-      # Bake the image user as the host UID/GID (from .env) so the bind-mounted
-      # workspace stays writable; 1050 default for portability.
       args:
         USER_UID: "${UID:-1050}"
         USER_GID: "${GID:-1050}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     env_file:
       - path: .env
     # Uncomment to pass through ESP32 device.
-    # devices:
-    #   - /dev/ttyACM0:/dev/ttyACM0
+    devices:
+      - /dev/ttyACM0:/dev/ttyACM0
     command: sleep infinity
     networks:
       - dust-mite-observability
@@ -67,6 +67,12 @@ services:
     build:
       context: .
       dockerfile: .devcontainer/js/Dockerfile
+      # Bake the image user as the host UID/GID (from .env) so the bind-mounted
+      # workspace stays writable; 1050 default for portability.
+      args:
+        USER_UID: "${UID:-1050}"
+        USER_GID: "${GID:-1050}"
+    user: "${UID:-1050}:${GID:-1050}"
     volumes:
       - .:/workspaces/dust-mite
     working_dir: /workspaces/dust-mite/web

--- a/scripts/start_headless.sh
+++ b/scripts/start_headless.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
-# .env (UID/GID from scripts/dump_env.sh) is the single source of truth for the
-# `user:` directive in the compose files, so the containers run as the host user
-# and bind-mounted build/ and caches stay writable.
 docker compose --env-file .env -f docker-compose.yml -f docker-compose.headless.yml up --build --remove-orphans -d

--- a/scripts/start_headless.sh
+++ b/scripts/start_headless.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
-docker compose -f docker-compose.yml -f docker-compose.headless.yml up --build --remove-orphans -d
+# .env (UID/GID from scripts/dump_env.sh) is the single source of truth for the
+# `user:` directive in the compose files, so the containers run as the host user
+# and bind-mounted build/ and caches stay writable.
+docker compose --env-file .env -f docker-compose.yml -f docker-compose.headless.yml up --build --remove-orphans -d

--- a/scripts/stop_headless.sh
+++ b/scripts/stop_headless.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
-docker compose -f docker-compose.yml -f docker-compose.headless.yml down
+# Use the same --env-file so compose resolves the same `user:` (host UID/GID).
+docker compose --env-file .env -f docker-compose.yml -f docker-compose.headless.yml down

--- a/scripts/stop_headless.sh
+++ b/scripts/stop_headless.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
-# Use the same --env-file so compose resolves the same `user:` (host UID/GID).
 docker compose --env-file .env -f docker-compose.yml -f docker-compose.headless.yml down


### PR DESCRIPTION
## Summary
- Headless/agent builds start the devcontainer compose files directly (no VS Code remap), so the container's baked-in `vscode` user (uid 1050) never matched the host-owned bind-mounted workspace — breaking ccache, the ESP-IDF component cache, and `build/` ownership with permission errors.
- Bakes `USER_UID`/`USER_GID` build args (sourced from `.env`, default `1050` for portability when `.env` is absent) into the cpp/python/js devcontainer images, and runs them as that same uid via `user:` — so the image's user *is* the host user with a real, writable `$HOME`.
- `scripts/start_headless.sh`/`scripts/stop_headless.sh` now pass `--env-file .env` instead of manually exporting `UID`/`GID` (`UID` is a read-only bash builtin, which made the previous approach fragile).
- `AGENTS.md` updated with the `--env-file .env` invocation and the now-obsolete cross-container `chown` workaround removed.

## Test plan
- [x] `docker compose --env-file .env -f .devcontainer/cpp/docker-compose.yml up -d --build cpp` → container runs as host uid, `$HOME` owned by host uid.
- [x] `idf.py build` and `idf.py -p /dev/ttyACM0 flash` succeed with no permission errors, no `--user` override, no manual `chown`.
- [x] Same verified for the python devcontainer image build.
- [x] `docker compose --env-file .env -f docker-compose.yml -f docker-compose.headless.yml up -d` (full headless stack) starts cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzjwGpxXu5m87QUqVfavhb