### PR TITLE
Add clang-format to car/ CI

### DIFF
--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -3,6 +3,7 @@ FROM espressif/idf:release-v6.0
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
     ccache \
+    clang-format \
     curl \
     locales \
     protobuf-compiler

--- a/.github/workflows/cpp-car.yml
+++ b/.github/workflows/cpp-car.yml
@@ -107,8 +107,34 @@ jobs:
         pytest ${{ matrix.pytest_pattern }} --embedded-services idf,qemu -v
       working-directory: ${{ matrix.path }}
 
+  run-checks:
+    needs: build-docker
+    permissions:
+      contents: read
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: ghcr.io/ltowarek/dust-mite-cpp-devcontainer
+      options: --user root
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./car
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Run formatter
+      run: ./scripts/run_formatter.sh -n --Werror
+
   ci-status-cpp-car:
-    needs: [build-docker, build]
+    needs: [build-docker, build, run-checks]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -414,6 +414,18 @@ idf.py flash
 idf.py monitor
 ```
 
+### Run quality checks
+
+```bash
+./scripts/run_checks.sh
+```
+
+If checks fail, apply automatic fixes (only reformats lines you've already staged with `git add`):
+
+```bash
+./scripts/fix_checks.sh
+```
+
 ### Car test types
 
 Test scope and execution environment are independent choices. Scope determines what is under test; environment determines where it runs.

--- a/car/.clang-format
+++ b/car/.clang-format
@@ -1,0 +1,8 @@
+---
+BasedOnStyle: Google
+ColumnLimit: 100
+IndentWidth: 2
+PointerAlignment: Left
+ReferenceAlignment: Left
+SortIncludes: false
+DerivePointerAlignment: false

--- a/car/components/camera/camera.cpp
+++ b/car/components/camera/camera.cpp
@@ -9,56 +9,56 @@
 
 static const char* TAG = "camera";
 
-#define CAM_PIN_PWDN  -1
+#define CAM_PIN_PWDN -1
 #define CAM_PIN_RESET -1
-#define CAM_PIN_XCLK  45
+#define CAM_PIN_XCLK 45
 
-#define CAM_PIN_D7    48
-#define CAM_PIN_D6    46
-#define CAM_PIN_D5    8
-#define CAM_PIN_D4    7
-#define CAM_PIN_D3    4
-#define CAM_PIN_D2    41
-#define CAM_PIN_D1    40
-#define CAM_PIN_D0    39
+#define CAM_PIN_D7 48
+#define CAM_PIN_D6 46
+#define CAM_PIN_D5 8
+#define CAM_PIN_D4 7
+#define CAM_PIN_D3 4
+#define CAM_PIN_D2 41
+#define CAM_PIN_D1 40
+#define CAM_PIN_D0 39
 #define CAM_PIN_VSYNC 6
-#define CAM_PIN_HREF  42
-#define CAM_PIN_PCLK  5
+#define CAM_PIN_HREF 42
+#define CAM_PIN_PCLK 5
 
 static camera_config_t camera_config = {
-  .pin_pwdn = CAM_PIN_PWDN,
-  .pin_reset = CAM_PIN_RESET,
-  .pin_xclk = CAM_PIN_XCLK,
-  .pin_sccb_sda = -1,
-  .pin_sccb_scl = -1,
+    .pin_pwdn = CAM_PIN_PWDN,
+    .pin_reset = CAM_PIN_RESET,
+    .pin_xclk = CAM_PIN_XCLK,
+    .pin_sccb_sda = -1,
+    .pin_sccb_scl = -1,
 
-  .pin_d7 = CAM_PIN_D7,
-  .pin_d6 = CAM_PIN_D6,
-  .pin_d5 = CAM_PIN_D5,
-  .pin_d4 = CAM_PIN_D4,
-  .pin_d3 = CAM_PIN_D3,
-  .pin_d2 = CAM_PIN_D2,
-  .pin_d1 = CAM_PIN_D1,
-  .pin_d0 = CAM_PIN_D0,
-  .pin_vsync = CAM_PIN_VSYNC,
-  .pin_href = CAM_PIN_HREF,
-  .pin_pclk = CAM_PIN_PCLK,
+    .pin_d7 = CAM_PIN_D7,
+    .pin_d6 = CAM_PIN_D6,
+    .pin_d5 = CAM_PIN_D5,
+    .pin_d4 = CAM_PIN_D4,
+    .pin_d3 = CAM_PIN_D3,
+    .pin_d2 = CAM_PIN_D2,
+    .pin_d1 = CAM_PIN_D1,
+    .pin_d0 = CAM_PIN_D0,
+    .pin_vsync = CAM_PIN_VSYNC,
+    .pin_href = CAM_PIN_HREF,
+    .pin_pclk = CAM_PIN_PCLK,
 
-  .xclk_freq_hz = 20000000,
+    .xclk_freq_hz = 20000000,
 
-  .ledc_timer = LEDC_TIMER_0,
-  .ledc_channel = LEDC_CHANNEL_0,
+    .ledc_timer = LEDC_TIMER_0,
+    .ledc_channel = LEDC_CHANNEL_0,
 
-  .pixel_format = PIXFORMAT_JPEG,
-  .frame_size = FRAMESIZE_VGA,
+    .pixel_format = PIXFORMAT_JPEG,
+    .frame_size = FRAMESIZE_VGA,
 
-  // Lower number = higher quality / larger JPEGs.
-  .jpeg_quality = 10,
-  .fb_count = 2,
-  .fb_location = CAMERA_FB_IN_PSRAM,
-  .grab_mode = CAMERA_GRAB_LATEST,
+    // Lower number = higher quality / larger JPEGs.
+    .jpeg_quality = 10,
+    .fb_count = 2,
+    .fb_location = CAMERA_FB_IN_PSRAM,
+    .grab_mode = CAMERA_GRAB_LATEST,
 
-  .sccb_i2c_port = 0,
+    .sccb_i2c_port = 0,
 };
 
 void camera_init(i2c_master_bus_handle_t i2c_bus) {
@@ -122,7 +122,7 @@ void camera_setup(QueueHandle_t frame_queue, i2c_master_bus_handle_t i2c_bus) {
     return;
   }
 
-  if (xTaskCreate(camera_task, "camera_task", 4096, (void *)0, 5, &g_camera_task_handle) != pdPASS) {
+  if (xTaskCreate(camera_task, "camera_task", 4096, (void*)0, 5, &g_camera_task_handle) != pdPASS) {
     ESP_LOGE(TAG, "xTaskCreate(camera_task) failed");
     return;
   }

--- a/car/components/camera/camera_metrics.cpp
+++ b/car/components/camera/camera_metrics.cpp
@@ -28,12 +28,12 @@ static opentelemetry::nostd::shared_ptr<metrics_api::ObservableInstrument> s_fra
 static size_t s_peak_frame_size = 0;
 
 static void cb_frame_size(metrics_api::ObserverResult obs, void*) {
-    size_t peak = s_peak_frame_size;
-    s_peak_frame_size = 0;
-    observe_int64(obs, static_cast<int64_t>(peak));
+  size_t peak = s_peak_frame_size;
+  s_peak_frame_size = 0;
+  observe_int64(obs, static_cast<int64_t>(peak));
 }
 static void cb_frame_buffer(metrics_api::ObserverResult obs, void*) {
-    observe_int64(obs, kFrameBufferBytes);
+  observe_int64(obs, kFrameBufferBytes);
 }
 
 }  // namespace
@@ -41,29 +41,28 @@ static void cb_frame_buffer(metrics_api::ObserverResult obs, void*) {
 
 void camera_metrics_setup() {
 #ifdef CONFIG_ESP_OPENTELEMETRY_METRICS_ENABLED
-    auto meter = metrics_api::Provider::GetMeterProvider()->GetMeter(
-        CONFIG_ESP_OPENTELEMETRY_SERVICE_NAME, "1.0.0");
+  auto meter = metrics_api::Provider::GetMeterProvider()->GetMeter(
+      CONFIG_ESP_OPENTELEMETRY_SERVICE_NAME, "1.0.0");
 
-    s_frames_captured = meter->CreateUInt64Counter(
-        "dust_mite.frames_captured", "Camera frames captured", "{frame}");
+  s_frames_captured =
+      meter->CreateUInt64Counter("dust_mite.frames_captured", "Camera frames captured", "{frame}");
 
-    s_frame_size = meter->CreateInt64ObservableGauge(
-        "dust_mite.camera.frame_size_bytes",
-        "Peak delivered JPEG frame size since last collection", "By");
-    s_frame_size->AddCallback(cb_frame_size, nullptr);
+  s_frame_size = meter->CreateInt64ObservableGauge(
+      "dust_mite.camera.frame_size_bytes", "Peak delivered JPEG frame size since last collection",
+      "By");
+  s_frame_size->AddCallback(cb_frame_size, nullptr);
 
-    s_frame_buffer = meter->CreateInt64ObservableGauge(
-        "dust_mite.camera.frame_buffer_bytes",
-        "JPEG frame-buffer capacity (drop limit)", "By");
-    s_frame_buffer->AddCallback(cb_frame_buffer, nullptr);
+  s_frame_buffer = meter->CreateInt64ObservableGauge(
+      "dust_mite.camera.frame_buffer_bytes", "JPEG frame-buffer capacity (drop limit)", "By");
+  s_frame_buffer->AddCallback(cb_frame_buffer, nullptr);
 #endif
 }
 
 void camera_metrics_update(size_t frame_size) {
 #ifdef CONFIG_ESP_OPENTELEMETRY_METRICS_ENABLED
-    if (s_frames_captured) s_frames_captured->Add(1);
-    if (frame_size > s_peak_frame_size) s_peak_frame_size = frame_size;
+  if (s_frames_captured) s_frames_captured->Add(1);
+  if (frame_size > s_peak_frame_size) s_peak_frame_size = frame_size;
 #else
-    (void)frame_size;
+  (void)frame_size;
 #endif
 }

--- a/car/components/camera/test_apps/main/test_camera.cpp
+++ b/car/components/camera/test_apps/main/test_camera.cpp
@@ -5,97 +5,91 @@
 #include "esp_camera.h"
 #include "driver/gpio.h"
 
-extern "C" void app_main(void)
-{
-    i2c_master_bus_config_t bus_cfg = {};
-    bus_cfg.i2c_port = I2C_NUM_0;
-    bus_cfg.sda_io_num = GPIO_NUM_1;
-    bus_cfg.scl_io_num = GPIO_NUM_2;
-    bus_cfg.clk_source = I2C_CLK_SRC_DEFAULT;
-    bus_cfg.glitch_ignore_cnt = 7;
-    bus_cfg.flags.enable_internal_pullup = true;
-    i2c_master_bus_handle_t i2c_bus;
-    ESP_ERROR_CHECK(i2c_new_master_bus(&bus_cfg, &i2c_bus));
-    camera_init(i2c_bus);
+extern "C" void app_main(void) {
+  i2c_master_bus_config_t bus_cfg = {};
+  bus_cfg.i2c_port = I2C_NUM_0;
+  bus_cfg.sda_io_num = GPIO_NUM_1;
+  bus_cfg.scl_io_num = GPIO_NUM_2;
+  bus_cfg.clk_source = I2C_CLK_SRC_DEFAULT;
+  bus_cfg.glitch_ignore_cnt = 7;
+  bus_cfg.flags.enable_internal_pullup = true;
+  i2c_master_bus_handle_t i2c_bus;
+  ESP_ERROR_CHECK(i2c_new_master_bus(&bus_cfg, &i2c_bus));
+  camera_init(i2c_bus);
 
-    UNITY_BEGIN();
-    unity_run_all_tests();
-    UNITY_END();
+  UNITY_BEGIN();
+  unity_run_all_tests();
+  UNITY_END();
 }
 
 void setUp(void) {}
 void tearDown(void) {}
 
-TEST_CASE("performance", "[camera]")
-{
-    const unsigned MEASUREMENTS = 100;
+TEST_CASE("performance", "[camera]") {
+  const unsigned MEASUREMENTS = 100;
 
-    uint64_t start = esp_timer_get_time();
-    for (int i = 0; i < MEASUREMENTS; i++) {
-        camera_fb_t * frame = esp_camera_fb_get();
-        esp_camera_fb_return(frame);
-    }
-    uint64_t end = esp_timer_get_time();
-
-    int fps = (int)((uint64_t)MEASUREMENTS * 1000000ULL / (end - start));
-
-    printf("%u iterations took %llu us (%d frames per second)\n",
-           MEASUREMENTS, end - start, fps);
-
-    TEST_ASSERT_INT_WITHIN(5, 25, fps);
-}
-
-TEST_CASE("throughput", "[camera]")
-{
-    const unsigned MEASUREMENTS = 100;
-
-    size_t frame_sizes = 0;
-
-    uint64_t start = esp_timer_get_time();
-    for (int i = 0; i < MEASUREMENTS; i++) {
-        camera_fb_t * frame = esp_camera_fb_get();
-        frame_sizes += frame->len;
-        esp_camera_fb_return(frame);
-    }
-    uint64_t end = esp_timer_get_time();
-
-    int throughput_mbps = (int)((uint64_t)frame_sizes * 8ULL / (end - start));
-
-    printf("%u iterations took %llu us with total frame size of %zu bytes (%d MBit/s)\n",
-           MEASUREMENTS, end - start, frame_sizes, throughput_mbps);
-
-    TEST_ASSERT_GREATER_THAN(1, throughput_mbps);
-}
-
-TEST_CASE("single_frame", "[camera]")
-{
-    camera_fb_t *frame = esp_camera_fb_get();
-    TEST_ASSERT_NOT_NULL(frame);
-    TEST_ASSERT_GREATER_OR_EQUAL(2, frame->len);
-    TEST_ASSERT_EQUAL_HEX8(0xFF, frame->buf[0]);
-    TEST_ASSERT_EQUAL_HEX8(0xD8, frame->buf[1]);
-    TEST_ASSERT_EQUAL_HEX8(0xFF, frame->buf[frame->len - 2]);
-    TEST_ASSERT_EQUAL_HEX8(0xD9, frame->buf[frame->len - 1]);
+  uint64_t start = esp_timer_get_time();
+  for (int i = 0; i < MEASUREMENTS; i++) {
+    camera_fb_t* frame = esp_camera_fb_get();
     esp_camera_fb_return(frame);
+  }
+  uint64_t end = esp_timer_get_time();
+
+  int fps = (int)((uint64_t)MEASUREMENTS * 1000000ULL / (end - start));
+
+  printf("%u iterations took %llu us (%d frames per second)\n", MEASUREMENTS, end - start, fps);
+
+  TEST_ASSERT_INT_WITHIN(5, 25, fps);
 }
 
-TEST_CASE("dma_stress", "[camera]")
-{
-    // Hold one frame buffer for 200 ms while the camera keeps producing to stress
-    // the DMA pool with fb_count=2 (slow consumer vs. fast producer).
-    camera_fb_t *frame1 = esp_camera_fb_get();
-    TEST_ASSERT_NOT_NULL(frame1);
+TEST_CASE("throughput", "[camera]") {
+  const unsigned MEASUREMENTS = 100;
 
-    vTaskDelay(pdMS_TO_TICKS(200));
+  size_t frame_sizes = 0;
 
-    // With CAMERA_GRAB_LATEST and one buffer held, the second slot should still
-    // be available and deliver a valid frame.
-    camera_fb_t *frame2 = esp_camera_fb_get();
-    TEST_ASSERT_NOT_NULL(frame2);
-    TEST_ASSERT_GREATER_OR_EQUAL(2, frame2->len);
-    TEST_ASSERT_EQUAL_HEX8(0xFF, frame2->buf[0]);
-    TEST_ASSERT_EQUAL_HEX8(0xD8, frame2->buf[1]);
+  uint64_t start = esp_timer_get_time();
+  for (int i = 0; i < MEASUREMENTS; i++) {
+    camera_fb_t* frame = esp_camera_fb_get();
+    frame_sizes += frame->len;
+    esp_camera_fb_return(frame);
+  }
+  uint64_t end = esp_timer_get_time();
 
-    esp_camera_fb_return(frame1);
-    esp_camera_fb_return(frame2);
+  int throughput_mbps = (int)((uint64_t)frame_sizes * 8ULL / (end - start));
+
+  printf("%u iterations took %llu us with total frame size of %zu bytes (%d MBit/s)\n",
+         MEASUREMENTS, end - start, frame_sizes, throughput_mbps);
+
+  TEST_ASSERT_GREATER_THAN(1, throughput_mbps);
+}
+
+TEST_CASE("single_frame", "[camera]") {
+  camera_fb_t* frame = esp_camera_fb_get();
+  TEST_ASSERT_NOT_NULL(frame);
+  TEST_ASSERT_GREATER_OR_EQUAL(2, frame->len);
+  TEST_ASSERT_EQUAL_HEX8(0xFF, frame->buf[0]);
+  TEST_ASSERT_EQUAL_HEX8(0xD8, frame->buf[1]);
+  TEST_ASSERT_EQUAL_HEX8(0xFF, frame->buf[frame->len - 2]);
+  TEST_ASSERT_EQUAL_HEX8(0xD9, frame->buf[frame->len - 1]);
+  esp_camera_fb_return(frame);
+}
+
+TEST_CASE("dma_stress", "[camera]") {
+  // Hold one frame buffer for 200 ms while the camera keeps producing to stress
+  // the DMA pool with fb_count=2 (slow consumer vs. fast producer).
+  camera_fb_t* frame1 = esp_camera_fb_get();
+  TEST_ASSERT_NOT_NULL(frame1);
+
+  vTaskDelay(pdMS_TO_TICKS(200));
+
+  // With CAMERA_GRAB_LATEST and one buffer held, the second slot should still
+  // be available and deliver a valid frame.
+  camera_fb_t* frame2 = esp_camera_fb_get();
+  TEST_ASSERT_NOT_NULL(frame2);
+  TEST_ASSERT_GREATER_OR_EQUAL(2, frame2->len);
+  TEST_ASSERT_EQUAL_HEX8(0xFF, frame2->buf[0]);
+  TEST_ASSERT_EQUAL_HEX8(0xD8, frame2->buf[1]);
+
+  esp_camera_fb_return(frame1);
+  esp_camera_fb_return(frame2);
 }

--- a/car/components/motor/include/motor.hpp
+++ b/car/components/motor/include/motor.hpp
@@ -29,7 +29,7 @@ typedef struct command_packet {
   int value;
 } command_packet_t;
 
-void command_task(void *p);
+void command_task(void* p);
 
 #ifdef __cplusplus
 }

--- a/car/components/motor/motor.cpp
+++ b/car/components/motor/motor.cpp
@@ -11,8 +11,8 @@ static const char* TAG = "motor";
 
 #define MOTOR_DEAD_ZONE 40
 #define MOTOR_PWM_RESOLUTION_HZ 1000000
-#define MOTOR_PWM_FREQ_HZ       1000
-#define MOTOR_PWM_PERIOD_TICKS  (MOTOR_PWM_RESOLUTION_HZ / MOTOR_PWM_FREQ_HZ)
+#define MOTOR_PWM_FREQ_HZ 1000
+#define MOTOR_PWM_PERIOD_TICKS (MOTOR_PWM_RESOLUTION_HZ / MOTOR_PWM_FREQ_HZ)
 
 typedef struct {
   int gpio_in1;
@@ -31,7 +31,7 @@ static motor_t m1 = {12, 13, 0, nullptr, nullptr, nullptr, nullptr, nullptr, nul
 // Front right
 static motor_t m2 = {14, 21, 0, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 // Rear left
-static motor_t m3 = {9,  10, 1, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+static motor_t m3 = {9, 10, 1, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 // Rear right
 static motor_t m4 = {47, 11, 1, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 
@@ -40,7 +40,7 @@ static motor_t* motors[4] = {&m1, &m2, &m3, &m4};
 static QueueHandle_t g_command_queue = NULL;
 static TaskHandle_t g_command_task_handle = NULL;
 
-void command_task(void *p) {
+void command_task(void* p) {
   command_packet_t packet = {0, 0};
   while (true) {
     if (xQueueReceive(g_command_queue, &packet, portMAX_DELAY) != pdPASS) {
@@ -115,14 +115,18 @@ static void motor_mcpwm_init(motor_t* m) {
   gen_cfg.gen_gpio_num = m->gpio_in2;
   ESP_ERROR_CHECK(mcpwm_new_generator(m->oper, &gen_cfg, &m->gen_b));
 
-  ESP_ERROR_CHECK(mcpwm_generator_set_action_on_timer_event(m->gen_a,
-      MCPWM_GEN_TIMER_EVENT_ACTION(MCPWM_TIMER_DIRECTION_UP, MCPWM_TIMER_EVENT_EMPTY, MCPWM_GEN_ACTION_HIGH)));
-  ESP_ERROR_CHECK(mcpwm_generator_set_action_on_compare_event(m->gen_a,
+  ESP_ERROR_CHECK(mcpwm_generator_set_action_on_timer_event(
+      m->gen_a, MCPWM_GEN_TIMER_EVENT_ACTION(MCPWM_TIMER_DIRECTION_UP, MCPWM_TIMER_EVENT_EMPTY,
+                                             MCPWM_GEN_ACTION_HIGH)));
+  ESP_ERROR_CHECK(mcpwm_generator_set_action_on_compare_event(
+      m->gen_a,
       MCPWM_GEN_COMPARE_EVENT_ACTION(MCPWM_TIMER_DIRECTION_UP, m->cmpr_a, MCPWM_GEN_ACTION_LOW)));
 
-  ESP_ERROR_CHECK(mcpwm_generator_set_action_on_timer_event(m->gen_b,
-      MCPWM_GEN_TIMER_EVENT_ACTION(MCPWM_TIMER_DIRECTION_UP, MCPWM_TIMER_EVENT_EMPTY, MCPWM_GEN_ACTION_HIGH)));
-  ESP_ERROR_CHECK(mcpwm_generator_set_action_on_compare_event(m->gen_b,
+  ESP_ERROR_CHECK(mcpwm_generator_set_action_on_timer_event(
+      m->gen_b, MCPWM_GEN_TIMER_EVENT_ACTION(MCPWM_TIMER_DIRECTION_UP, MCPWM_TIMER_EVENT_EMPTY,
+                                             MCPWM_GEN_ACTION_HIGH)));
+  ESP_ERROR_CHECK(mcpwm_generator_set_action_on_compare_event(
+      m->gen_b,
       MCPWM_GEN_COMPARE_EVENT_ACTION(MCPWM_TIMER_DIRECTION_UP, m->cmpr_b, MCPWM_GEN_ACTION_LOW)));
 
   // Start with both outputs forced low
@@ -144,14 +148,14 @@ void motor_setup(QueueHandle_t command_queue) {
   servo_init();
 
   g_command_queue = command_queue;
-  if (xTaskCreate(command_task, "command_task", 4096, (void *)0, 1, &g_command_task_handle) != pdPASS) {
+  if (xTaskCreate(command_task, "command_task", 4096, (void*)0, 1, &g_command_task_handle) !=
+      pdPASS) {
     ESP_LOGE(TAG, "xTaskCreate(command_task) failed");
     return;
   }
 }
 
-static void motor_advance(motor_t* motor, uint8_t speed)
-{
+static void motor_advance(motor_t* motor, uint8_t speed) {
   speed = (uint8_t)interpolate(speed, 0, 100, MOTOR_DEAD_ZONE, 100);
   uint32_t cmp = (uint32_t)speed * MOTOR_PWM_PERIOD_TICKS / 100;
   ESP_ERROR_CHECK(mcpwm_comparator_set_compare_value(motor->cmpr_a, cmp));
@@ -159,8 +163,7 @@ static void motor_advance(motor_t* motor, uint8_t speed)
   ESP_ERROR_CHECK(mcpwm_generator_set_force_level(motor->gen_a, -1, false));
 }
 
-static void motor_retreat(motor_t* motor, uint8_t speed)
-{
+static void motor_retreat(motor_t* motor, uint8_t speed) {
   speed = (uint8_t)interpolate(speed, 0, 100, MOTOR_DEAD_ZONE, 100);
   uint32_t cmp = (uint32_t)speed * MOTOR_PWM_PERIOD_TICKS / 100;
   ESP_ERROR_CHECK(mcpwm_comparator_set_compare_value(motor->cmpr_b, cmp));
@@ -168,44 +171,38 @@ static void motor_retreat(motor_t* motor, uint8_t speed)
   ESP_ERROR_CHECK(mcpwm_generator_set_force_level(motor->gen_b, -1, false));
 }
 
-static void motor_brake(motor_t* motor)
-{
+static void motor_brake(motor_t* motor) {
   ESP_ERROR_CHECK(mcpwm_generator_set_force_level(motor->gen_a, 1, true));
   ESP_ERROR_CHECK(mcpwm_generator_set_force_level(motor->gen_b, 1, true));
 }
 
-void car_advance(uint8_t speed)
-{
+void car_advance(uint8_t speed) {
   for (int i = 0; i < 4; i++) {
     motor_advance(motors[i], speed);
   }
 }
 
-void car_retreat(uint8_t speed)
-{
+void car_retreat(uint8_t speed) {
   for (int i = 0; i < 4; i++) {
     motor_retreat(motors[i], speed);
   }
 }
 
-void car_turn_left(uint8_t speed)
-{
+void car_turn_left(uint8_t speed) {
   motor_advance(&m2, speed);
   motor_advance(&m4, speed);
   motor_retreat(&m1, speed);
   motor_retreat(&m3, speed);
 }
 
-void car_turn_right(uint8_t speed)
-{
+void car_turn_right(uint8_t speed) {
   motor_advance(&m1, speed);
   motor_advance(&m3, speed);
   motor_retreat(&m2, speed);
   motor_retreat(&m4, speed);
 }
 
-void car_brake()
-{
+void car_brake() {
   for (int i = 0; i < 4; i++) {
     motor_brake(motors[i]);
   }

--- a/car/components/motor/servo.cpp
+++ b/car/components/motor/servo.cpp
@@ -9,8 +9,8 @@
 #define MAX_DUTY 2400
 
 #define SERVO_PWM_RESOLUTION_HZ 1000000
-#define SERVO_PWM_FREQ_HZ       50
-#define SERVO_PWM_PERIOD_TICKS  (SERVO_PWM_RESOLUTION_HZ / SERVO_PWM_FREQ_HZ)
+#define SERVO_PWM_FREQ_HZ 50
+#define SERVO_PWM_PERIOD_TICKS (SERVO_PWM_RESOLUTION_HZ / SERVO_PWM_FREQ_HZ)
 
 typedef struct {
   int gpio_in;
@@ -21,7 +21,7 @@ typedef struct {
   mcpwm_gen_handle_t gen;
 } servo_t;
 
-static servo_t pan_servo  = {3,  0, nullptr, nullptr, nullptr, nullptr};
+static servo_t pan_servo = {3, 0, nullptr, nullptr, nullptr, nullptr};
 static servo_t tilt_servo = {38, 1, nullptr, nullptr, nullptr, nullptr};
 
 static int map_angle_to_duty(int angle) {
@@ -52,9 +52,11 @@ static void servo_mcpwm_init(servo_t* s) {
   ESP_ERROR_CHECK(mcpwm_new_generator(s->oper, &gen_cfg, &s->gen));
 
   // High on timer empty, low on comparator match — standard servo PWM
-  ESP_ERROR_CHECK(mcpwm_generator_set_action_on_timer_event(s->gen,
-      MCPWM_GEN_TIMER_EVENT_ACTION(MCPWM_TIMER_DIRECTION_UP, MCPWM_TIMER_EVENT_EMPTY, MCPWM_GEN_ACTION_HIGH)));
-  ESP_ERROR_CHECK(mcpwm_generator_set_action_on_compare_event(s->gen,
+  ESP_ERROR_CHECK(mcpwm_generator_set_action_on_timer_event(
+      s->gen, MCPWM_GEN_TIMER_EVENT_ACTION(MCPWM_TIMER_DIRECTION_UP, MCPWM_TIMER_EVENT_EMPTY,
+                                           MCPWM_GEN_ACTION_HIGH)));
+  ESP_ERROR_CHECK(mcpwm_generator_set_action_on_compare_event(
+      s->gen,
       MCPWM_GEN_COMPARE_EVENT_ACTION(MCPWM_TIMER_DIRECTION_UP, s->cmpr, MCPWM_GEN_ACTION_LOW)));
 
   ESP_ERROR_CHECK(mcpwm_timer_enable(s->timer));

--- a/car/components/motor/test_apps/main/main.cpp
+++ b/car/components/motor/test_apps/main/main.cpp
@@ -3,14 +3,13 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
 
-extern "C" void app_main(void)
-{
-    QueueHandle_t command_queue = xQueueCreate(2, sizeof(command_packet_t));
-    motor_setup(command_queue);  // also calls servo_init() internally
+extern "C" void app_main(void) {
+  QueueHandle_t command_queue = xQueueCreate(2, sizeof(command_packet_t));
+  motor_setup(command_queue);  // also calls servo_init() internally
 
-    UNITY_BEGIN();
-    unity_run_all_tests();
-    UNITY_END();
+  UNITY_BEGIN();
+  unity_run_all_tests();
+  UNITY_END();
 }
 
 void setUp(void) {}

--- a/car/components/motor/test_apps/main/test_motor.cpp
+++ b/car/components/motor/test_apps/main/test_motor.cpp
@@ -3,8 +3,28 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
-TEST_CASE("advance",    "[motor]") { car_advance(50);    vTaskDelay(pdMS_TO_TICKS(1000)); car_brake(); }
-TEST_CASE("retreat",    "[motor]") { car_retreat(50);    vTaskDelay(pdMS_TO_TICKS(1000)); car_brake(); }
-TEST_CASE("brake",      "[motor]") { car_advance(50);    vTaskDelay(pdMS_TO_TICKS(500));  car_brake(); }
-TEST_CASE("turn_left",  "[motor]") { car_turn_left(50);  vTaskDelay(pdMS_TO_TICKS(1000)); car_brake(); }
-TEST_CASE("turn_right", "[motor]") { car_turn_right(50); vTaskDelay(pdMS_TO_TICKS(1000)); car_brake(); }
+TEST_CASE("advance", "[motor]") {
+  car_advance(50);
+  vTaskDelay(pdMS_TO_TICKS(1000));
+  car_brake();
+}
+TEST_CASE("retreat", "[motor]") {
+  car_retreat(50);
+  vTaskDelay(pdMS_TO_TICKS(1000));
+  car_brake();
+}
+TEST_CASE("brake", "[motor]") {
+  car_advance(50);
+  vTaskDelay(pdMS_TO_TICKS(500));
+  car_brake();
+}
+TEST_CASE("turn_left", "[motor]") {
+  car_turn_left(50);
+  vTaskDelay(pdMS_TO_TICKS(1000));
+  car_brake();
+}
+TEST_CASE("turn_right", "[motor]") {
+  car_turn_right(50);
+  vTaskDelay(pdMS_TO_TICKS(1000));
+  car_brake();
+}

--- a/car/components/motor/test_apps/main/test_servo.cpp
+++ b/car/components/motor/test_apps/main/test_servo.cpp
@@ -2,48 +2,46 @@
 #include "unity.h"
 #include "esp_log.h"
 
-TEST_CASE("pan", "[servo]")
-{
-    int angle = 0;
-    ESP_LOGI("test", "Angle: %d", angle);
-    move_pan(angle);
-    vTaskDelay(pdMS_TO_TICKS(1000));
+TEST_CASE("pan", "[servo]") {
+  int angle = 0;
+  ESP_LOGI("test", "Angle: %d", angle);
+  move_pan(angle);
+  vTaskDelay(pdMS_TO_TICKS(1000));
 
-    angle = 90;
-    ESP_LOGI("test", "Angle: %d", angle);
-    move_pan(angle);
-    vTaskDelay(pdMS_TO_TICKS(1000));
+  angle = 90;
+  ESP_LOGI("test", "Angle: %d", angle);
+  move_pan(angle);
+  vTaskDelay(pdMS_TO_TICKS(1000));
 
-    angle = -90;
-    ESP_LOGI("test", "Angle: %d", angle);
-    move_pan(angle);
-    vTaskDelay(pdMS_TO_TICKS(1000));
+  angle = -90;
+  ESP_LOGI("test", "Angle: %d", angle);
+  move_pan(angle);
+  vTaskDelay(pdMS_TO_TICKS(1000));
 
-    angle = 0;
-    ESP_LOGI("test", "Angle: %d", angle);
-    move_pan(angle);
-    vTaskDelay(pdMS_TO_TICKS(1000));
+  angle = 0;
+  ESP_LOGI("test", "Angle: %d", angle);
+  move_pan(angle);
+  vTaskDelay(pdMS_TO_TICKS(1000));
 }
 
-TEST_CASE("tilt", "[servo]")
-{
-    int angle = 0;
-    ESP_LOGI("test", "Angle: %d", angle);
-    move_tilt(angle);
-    vTaskDelay(pdMS_TO_TICKS(1000));
+TEST_CASE("tilt", "[servo]") {
+  int angle = 0;
+  ESP_LOGI("test", "Angle: %d", angle);
+  move_tilt(angle);
+  vTaskDelay(pdMS_TO_TICKS(1000));
 
-    angle = 90;
-    ESP_LOGI("test", "Angle: %d", angle);
-    move_tilt(angle);
-    vTaskDelay(pdMS_TO_TICKS(1000));
+  angle = 90;
+  ESP_LOGI("test", "Angle: %d", angle);
+  move_tilt(angle);
+  vTaskDelay(pdMS_TO_TICKS(1000));
 
-    angle = -90;
-    ESP_LOGI("test", "Angle: %d", angle);
-    move_tilt(angle);
-    vTaskDelay(pdMS_TO_TICKS(1000));
+  angle = -90;
+  ESP_LOGI("test", "Angle: %d", angle);
+  move_tilt(angle);
+  vTaskDelay(pdMS_TO_TICKS(1000));
 
-    angle = 0;
-    ESP_LOGI("test", "Angle: %d", angle);
-    move_tilt(angle);
-    vTaskDelay(pdMS_TO_TICKS(1000));
+  angle = 0;
+  ESP_LOGI("test", "Angle: %d", angle);
+  move_tilt(angle);
+  vTaskDelay(pdMS_TO_TICKS(1000));
 }

--- a/car/components/telemetry/include/telemetry_types.hpp
+++ b/car/components/telemetry/include/telemetry_types.hpp
@@ -13,7 +13,7 @@ typedef struct {
 } vector3_t;
 
 typedef struct {
-  char timestamp[20+1];
+  char timestamp[20 + 1];
   int rssi;
   float speed;
   vector3_t accelerometer;
@@ -22,7 +22,7 @@ typedef struct {
   int distance_ahead;
 } telemetry_packet_t;
 
-cJSON* convert_telemetry_packet_to_json(const telemetry_packet_t &p);
+cJSON* convert_telemetry_packet_to_json(const telemetry_packet_t& p);
 
 #ifdef __cplusplus
 }

--- a/car/components/telemetry/telemetry.cpp
+++ b/car/components/telemetry/telemetry.cpp
@@ -29,7 +29,7 @@ static pcnt_unit_handle_t g_pcnt_unit = NULL;
 static uint64_t g_previous_timestamp = 0;
 
 static i2c_master_dev_handle_t g_imu_xm_dev = NULL;
-static i2c_master_dev_handle_t g_imu_g_dev  = NULL;
+static i2c_master_dev_handle_t g_imu_g_dev = NULL;
 
 // Based on:
 // https://github.com/adafruit/Adafruit_LSM9DS0_Library/
@@ -48,9 +48,9 @@ static i2c_master_dev_handle_t g_imu_g_dev  = NULL;
 #define LSM9DS0_REGISTER_OUT_A 0x28
 #define LSM9DS0_REGISTER_OUT_M 0x08
 #define LSM9DS0_REGISTER_OUT_G 0x28
-#define LSM9DS0_RESOLUTION_A (0.00006103515f) // scale/ADC tick -> 2g/0x8000
-#define LSM9DS0_RESOLUTION_M (0.00006103515f) // scale/ADC tick -> 2G/0x8000
-#define LSM9DS0_RESOLUTION_G (0.00747680664f) // scale/ADC tick -> 245DPS/0x8000
+#define LSM9DS0_RESOLUTION_A (0.00006103515f)  // scale/ADC tick -> 2g/0x8000
+#define LSM9DS0_RESOLUTION_M (0.00006103515f)  // scale/ADC tick -> 2G/0x8000
+#define LSM9DS0_RESOLUTION_G (0.00747680664f)  // scale/ADC tick -> 245DPS/0x8000
 
 #define URM_ECHO_PIN GPIO_NUM_17
 #define URM_TRIG_PIN GPIO_NUM_16
@@ -66,13 +66,13 @@ void sync_time() {
   ESP_LOGI(TAG, "Set system time");
 }
 
-void get_timestamp(char *buf) {
+void get_timestamp(char* buf) {
   time_t now;
   time(&now);
   tm timeinfo = {};
   gmtime_r(&now, &timeinfo);
 
-  strftime(buf, (20+1) * sizeof(char), "%Y-%m-%dT%H:%M:%SZ", &timeinfo);
+  strftime(buf, (20 + 1) * sizeof(char), "%Y-%m-%dT%H:%M:%SZ", &timeinfo);
   buf[20] = '\0';
 }
 
@@ -82,7 +82,7 @@ int get_rssi() {
   return rssi;
 }
 
-void get_telemetry_packet(telemetry_packet_t *p) {
+void get_telemetry_packet(telemetry_packet_t* p) {
   get_timestamp(p->timestamp);
   p->rssi = get_rssi();
   p->speed = get_speed();
@@ -108,7 +108,8 @@ void pcnt_init() {
   pcnt_channel_handle_t pcnt_channel = NULL;
   ESP_ERROR_CHECK(pcnt_new_channel(g_pcnt_unit, &pcnt_channel_config, &pcnt_channel));
 
-  ESP_ERROR_CHECK(pcnt_channel_set_edge_action(pcnt_channel, PCNT_CHANNEL_EDGE_ACTION_HOLD, PCNT_CHANNEL_EDGE_ACTION_INCREASE));
+  ESP_ERROR_CHECK(pcnt_channel_set_edge_action(pcnt_channel, PCNT_CHANNEL_EDGE_ACTION_HOLD,
+                                               PCNT_CHANNEL_EDGE_ACTION_INCREASE));
   ESP_ERROR_CHECK(pcnt_unit_add_watch_point(g_pcnt_unit, pcnt_limit));
   ESP_ERROR_CHECK(pcnt_unit_clear_count(g_pcnt_unit));
   ESP_ERROR_CHECK(pcnt_unit_enable(g_pcnt_unit));
@@ -142,24 +143,24 @@ float get_rpm() {
   float revolutions_per_second = pulses_per_second / encoder_slots;
   float revolutions_per_minute = revolutions_per_second * 60;
   return revolutions_per_minute;
-
 }
 
 float get_speed() {
   float revolutions_per_minute = get_rpm();
   float wheel_diameter_m = 0.066f;  // 6,6 cm
   // S = RPM * DIAMETER_IN_METERS * PI * MINUTES_IN_HOUR/METERS_IN_KILOMETER
-  float velocity_kph = revolutions_per_minute * wheel_diameter_m * 3.14f * 60/1000;
+  float velocity_kph = revolutions_per_minute * wheel_diameter_m * 3.14f * 60 / 1000;
   return velocity_kph;
 }
 
 static i2c_master_dev_handle_t imu_dev_handle(uint8_t device_address) {
   if (device_address == LSM9DS0_XM_ADDRESS) return g_imu_xm_dev;
-  if (device_address == LSM9DS0_G_ADDRESS)  return g_imu_g_dev;
+  if (device_address == LSM9DS0_G_ADDRESS) return g_imu_g_dev;
   return NULL;
 }
 
-void imu_read_register(uint8_t device_address, uint8_t reg_address, uint8_t* read_buf, size_t read_size) {
+void imu_read_register(uint8_t device_address, uint8_t reg_address, uint8_t* read_buf,
+                       size_t read_size) {
   i2c_master_dev_handle_t dev = imu_dev_handle(device_address);
   if (!dev) return;
   uint8_t write_buf = reg_address | 0x80;  // Enable reading multiple bytes
@@ -192,13 +193,18 @@ void imu_init(i2c_master_bus_handle_t bus_handle) {
   imu_read_register(LSM9DS0_XM_ADDRESS, LSM9DS0_REGISTER_WHO_AM_I_XM, &xm_id, 1);
   ESP_ERROR_CHECK(xm_id == LSM9DS0_XM_ID ? ESP_OK : ESP_FAIL);
 
-  imu_write_register(LSM9DS0_XM_ADDRESS, LSM9DS0_REGISTER_CTRL_REG1_XM, 0x67); // Accelerometer 100Hz data rate, x/y/z enabled
+  imu_write_register(LSM9DS0_XM_ADDRESS, LSM9DS0_REGISTER_CTRL_REG1_XM,
+                     0x67);  // Accelerometer 100Hz data rate, x/y/z enabled
 
-  imu_write_register(LSM9DS0_XM_ADDRESS, LSM9DS0_REGISTER_CTRL_REG5_XM, 0x94); // Magnetometer 100Hz data rate, temperature enabled
-  imu_write_register(LSM9DS0_XM_ADDRESS, LSM9DS0_REGISTER_CTRL_REG6_XM, 0x00); // Magnetometer 2G scale
-  imu_write_register(LSM9DS0_XM_ADDRESS, LSM9DS0_REGISTER_CTRL_REG7_XM, 0x00); // Magnetometer continuous-conversion mode
+  imu_write_register(LSM9DS0_XM_ADDRESS, LSM9DS0_REGISTER_CTRL_REG5_XM,
+                     0x94);  // Magnetometer 100Hz data rate, temperature enabled
+  imu_write_register(LSM9DS0_XM_ADDRESS, LSM9DS0_REGISTER_CTRL_REG6_XM,
+                     0x00);  // Magnetometer 2G scale
+  imu_write_register(LSM9DS0_XM_ADDRESS, LSM9DS0_REGISTER_CTRL_REG7_XM,
+                     0x00);  // Magnetometer continuous-conversion mode
 
-  imu_write_register(LSM9DS0_G_ADDRESS, LSM9DS0_REGISTER_CTRL_REG1_G, 0x0F); // Gyroscope normal mode, x/y/z enabled
+  imu_write_register(LSM9DS0_G_ADDRESS, LSM9DS0_REGISTER_CTRL_REG1_G,
+                     0x0F);  // Gyroscope normal mode, x/y/z enabled
 }
 
 vector3_t read_accelerometer() {
@@ -210,9 +216,9 @@ vector3_t read_accelerometer() {
   int16_t raw_z = (buf[5] << 8) | buf[4];
 
   vector3_t out;
-  out.x = (float)(raw_x) * LSM9DS0_RESOLUTION_A;
-  out.y = (float)(raw_y) * LSM9DS0_RESOLUTION_A;
-  out.z = (float)(raw_z) * LSM9DS0_RESOLUTION_A * -1;  // Module is mounted upside down
+  out.x = (float)(raw_x)*LSM9DS0_RESOLUTION_A;
+  out.y = (float)(raw_y)*LSM9DS0_RESOLUTION_A;
+  out.z = (float)(raw_z)*LSM9DS0_RESOLUTION_A * -1;  // Module is mounted upside down
   return out;
 }
 
@@ -225,9 +231,9 @@ vector3_t read_magnetometer() {
   int16_t raw_z = (buf[5] << 8) | buf[4];
 
   vector3_t out;
-  out.x = (float)(raw_x) * LSM9DS0_RESOLUTION_M;
-  out.y = (float)(raw_y) * LSM9DS0_RESOLUTION_M;
-  out.z = (float)(raw_z) * LSM9DS0_RESOLUTION_M;
+  out.x = (float)(raw_x)*LSM9DS0_RESOLUTION_M;
+  out.y = (float)(raw_y)*LSM9DS0_RESOLUTION_M;
+  out.z = (float)(raw_z)*LSM9DS0_RESOLUTION_M;
   return out;
 }
 
@@ -240,16 +246,17 @@ vector3_t read_gyroscope() {
   int16_t raw_z = (buf[5] << 8) | buf[4];
 
   vector3_t out;
-  out.x = (float)(raw_x) * LSM9DS0_RESOLUTION_G;
-  out.y = (float)(raw_y) * LSM9DS0_RESOLUTION_G;
-  out.z = (float)(raw_z) * LSM9DS0_RESOLUTION_G;
+  out.x = (float)(raw_x)*LSM9DS0_RESOLUTION_G;
+  out.y = (float)(raw_y)*LSM9DS0_RESOLUTION_G;
+  out.z = (float)(raw_z)*LSM9DS0_RESOLUTION_G;
   return out;
 }
 
 static uint32_t g_cap_resolution_hz = 0;
 static mcpwm_cap_channel_handle_t g_cap_channel = NULL;
 
-static bool urm_echo_isr_handler(mcpwm_cap_channel_handle_t cap_channel, const mcpwm_capture_event_data_t *edata, void *user_data) {
+static bool urm_echo_isr_handler(mcpwm_cap_channel_handle_t cap_channel,
+                                 const mcpwm_capture_event_data_t* edata, void* user_data) {
   static uint32_t begin_of_sample = 0;
   static uint32_t end_of_sample = 0;
 
@@ -261,7 +268,8 @@ static bool urm_echo_isr_handler(mcpwm_cap_channel_handle_t cap_channel, const m
     end_of_sample = edata->cap_value;
     uint32_t pulse_count = end_of_sample - begin_of_sample;
     if (g_urm_waiting_task != NULL) {
-      xTaskNotifyIndexedFromISR(g_urm_waiting_task, TELEMETRY_URM_ISR_INDEX, pulse_count, eSetValueWithOverwrite, &high_task_wakeup);
+      xTaskNotifyIndexedFromISR(g_urm_waiting_task, TELEMETRY_URM_ISR_INDEX, pulse_count,
+                                eSetValueWithOverwrite, &high_task_wakeup);
     }
   }
   return high_task_wakeup == pdTRUE;
@@ -310,7 +318,8 @@ int get_distance_ahead() {
   ESP_ERROR_CHECK(gpio_set_level(URM_TRIG_PIN, 1));
 
   uint32_t pulse_count = 0;
-  bool notified = xTaskNotifyWaitIndexed(TELEMETRY_URM_ISR_INDEX, 0x00, ULONG_MAX, &pulse_count, pdMS_TO_TICKS(1000)) == pdTRUE;
+  bool notified = xTaskNotifyWaitIndexed(TELEMETRY_URM_ISR_INDEX, 0x00, ULONG_MAX, &pulse_count,
+                                         pdMS_TO_TICKS(1000)) == pdTRUE;
   g_urm_waiting_task = NULL;
 
   if (notified) {
@@ -371,7 +380,8 @@ void telemetry_setup(QueueHandle_t telemetry_queue, i2c_master_bus_handle_t i2c_
 
   telemetry_init(i2c_bus);
 
-  if (xTaskCreate(telemetry_task, "telemetry_task", 4096, (void *)0, 1, &g_telemetry_task_handle) != pdPASS) {
+  if (xTaskCreate(telemetry_task, "telemetry_task", 4096, (void*)0, 1, &g_telemetry_task_handle) !=
+      pdPASS) {
     ESP_LOGE(TAG, "xTaskCreate(telemetry_task) failed");
     return;
   }

--- a/car/components/telemetry/telemetry_json.cpp
+++ b/car/components/telemetry/telemetry_json.cpp
@@ -1,23 +1,23 @@
 #include "telemetry_types.hpp"
 #include <cJSON.h>
 
-cJSON* convert_telemetry_packet_to_json(const telemetry_packet_t &p) {
-  cJSON* root=cJSON_CreateObject();
+cJSON* convert_telemetry_packet_to_json(const telemetry_packet_t& p) {
+  cJSON* root = cJSON_CreateObject();
   cJSON_AddStringToObject(root, "timestamp", p.timestamp);
   cJSON_AddNumberToObject(root, "rssi", p.rssi);
   cJSON_AddNumberToObject(root, "speed", p.speed);
 
-  cJSON* accelerometer=cJSON_AddObjectToObject(root, "accelerometer");
+  cJSON* accelerometer = cJSON_AddObjectToObject(root, "accelerometer");
   cJSON_AddNumberToObject(accelerometer, "x", p.accelerometer.x);
   cJSON_AddNumberToObject(accelerometer, "y", p.accelerometer.y);
   cJSON_AddNumberToObject(accelerometer, "z", p.accelerometer.z);
 
-  cJSON* magnetometer=cJSON_AddObjectToObject(root, "magnetometer");
+  cJSON* magnetometer = cJSON_AddObjectToObject(root, "magnetometer");
   cJSON_AddNumberToObject(magnetometer, "x", p.magnetometer.x);
   cJSON_AddNumberToObject(magnetometer, "y", p.magnetometer.y);
   cJSON_AddNumberToObject(magnetometer, "z", p.magnetometer.z);
 
-  cJSON* gyroscope=cJSON_AddObjectToObject(root, "gyroscope");
+  cJSON* gyroscope = cJSON_AddObjectToObject(root, "gyroscope");
   cJSON_AddNumberToObject(gyroscope, "x", p.gyroscope.x);
   cJSON_AddNumberToObject(gyroscope, "y", p.gyroscope.y);
   cJSON_AddNumberToObject(gyroscope, "z", p.gyroscope.z);

--- a/car/components/telemetry/telemetry_metrics.cpp
+++ b/car/components/telemetry/telemetry_metrics.cpp
@@ -13,97 +13,133 @@ namespace metrics_api = opentelemetry::metrics;
 namespace {
 
 struct State {
-    int   rssi           = 0;
-    float speed          = 0.0f;
-    int   distance_ahead = 0;
-    float accel_x = 0.0f, accel_y = 0.0f, accel_z = 0.0f;
-    float mag_x   = 0.0f, mag_y   = 0.0f, mag_z   = 0.0f;
-    float gyro_x  = 0.0f, gyro_y  = 0.0f, gyro_z  = 0.0f;
+  int rssi = 0;
+  float speed = 0.0f;
+  int distance_ahead = 0;
+  float accel_x = 0.0f, accel_y = 0.0f, accel_z = 0.0f;
+  float mag_x = 0.0f, mag_y = 0.0f, mag_z = 0.0f;
+  float gyro_x = 0.0f, gyro_y = 0.0f, gyro_z = 0.0f;
 };
 
-static State              s_state;
-static SemaphoreHandle_t  s_mutex = NULL;
+static State s_state;
+static SemaphoreHandle_t s_mutex = NULL;
 
 static State snapshot_state() {
-    State snap;
-    xSemaphoreTake(s_mutex, portMAX_DELAY);
-    snap = s_state;
-    xSemaphoreGive(s_mutex);
-    return snap;
+  State snap;
+  xSemaphoreTake(s_mutex, portMAX_DELAY);
+  snap = s_state;
+  xSemaphoreGive(s_mutex);
+  return snap;
 }
 
-static void cb_rssi(metrics_api::ObserverResult obs, void*)           { observe_int64(obs, snapshot_state().rssi); }
-static void cb_speed(metrics_api::ObserverResult obs, void*)          { observe_double(obs, snapshot_state().speed); }
-static void cb_distance_ahead(metrics_api::ObserverResult obs, void*) { observe_int64(obs, snapshot_state().distance_ahead); }
-static void cb_accel_x(metrics_api::ObserverResult obs, void*)        { observe_double(obs, snapshot_state().accel_x); }
-static void cb_accel_y(metrics_api::ObserverResult obs, void*)        { observe_double(obs, snapshot_state().accel_y); }
-static void cb_accel_z(metrics_api::ObserverResult obs, void*)        { observe_double(obs, snapshot_state().accel_z); }
-static void cb_mag_x(metrics_api::ObserverResult obs, void*)          { observe_double(obs, snapshot_state().mag_x); }
-static void cb_mag_y(metrics_api::ObserverResult obs, void*)          { observe_double(obs, snapshot_state().mag_y); }
-static void cb_mag_z(metrics_api::ObserverResult obs, void*)          { observe_double(obs, snapshot_state().mag_z); }
-static void cb_gyro_x(metrics_api::ObserverResult obs, void*)         { observe_double(obs, snapshot_state().gyro_x); }
-static void cb_gyro_y(metrics_api::ObserverResult obs, void*)         { observe_double(obs, snapshot_state().gyro_y); }
-static void cb_gyro_z(metrics_api::ObserverResult obs, void*)         { observe_double(obs, snapshot_state().gyro_z); }
+static void cb_rssi(metrics_api::ObserverResult obs, void*) {
+  observe_int64(obs, snapshot_state().rssi);
+}
+static void cb_speed(metrics_api::ObserverResult obs, void*) {
+  observe_double(obs, snapshot_state().speed);
+}
+static void cb_distance_ahead(metrics_api::ObserverResult obs, void*) {
+  observe_int64(obs, snapshot_state().distance_ahead);
+}
+static void cb_accel_x(metrics_api::ObserverResult obs, void*) {
+  observe_double(obs, snapshot_state().accel_x);
+}
+static void cb_accel_y(metrics_api::ObserverResult obs, void*) {
+  observe_double(obs, snapshot_state().accel_y);
+}
+static void cb_accel_z(metrics_api::ObserverResult obs, void*) {
+  observe_double(obs, snapshot_state().accel_z);
+}
+static void cb_mag_x(metrics_api::ObserverResult obs, void*) {
+  observe_double(obs, snapshot_state().mag_x);
+}
+static void cb_mag_y(metrics_api::ObserverResult obs, void*) {
+  observe_double(obs, snapshot_state().mag_y);
+}
+static void cb_mag_z(metrics_api::ObserverResult obs, void*) {
+  observe_double(obs, snapshot_state().mag_z);
+}
+static void cb_gyro_x(metrics_api::ObserverResult obs, void*) {
+  observe_double(obs, snapshot_state().gyro_x);
+}
+static void cb_gyro_y(metrics_api::ObserverResult obs, void*) {
+  observe_double(obs, snapshot_state().gyro_y);
+}
+static void cb_gyro_z(metrics_api::ObserverResult obs, void*) {
+  observe_double(obs, snapshot_state().gyro_z);
+}
 
 static constexpr size_t kNumInstruments = 12;
-static opentelemetry::nostd::shared_ptr<metrics_api::ObservableInstrument> s_instruments[kNumInstruments];
+static opentelemetry::nostd::shared_ptr<metrics_api::ObservableInstrument>
+    s_instruments[kNumInstruments];
 
 }  // namespace
 #endif  // CONFIG_ESP_OPENTELEMETRY_METRICS_ENABLED
 
 void telemetry_metrics_setup() {
 #ifdef CONFIG_ESP_OPENTELEMETRY_METRICS_ENABLED
-    s_mutex = xSemaphoreCreateMutex();
+  s_mutex = xSemaphoreCreateMutex();
 
-    auto meter = metrics_api::Provider::GetMeterProvider()->GetMeter(
-        CONFIG_ESP_OPENTELEMETRY_SERVICE_NAME, "1.0.0");
+  auto meter = metrics_api::Provider::GetMeterProvider()->GetMeter(
+      CONFIG_ESP_OPENTELEMETRY_SERVICE_NAME, "1.0.0");
 
-    static_assert(kNumInstruments == 12, "Update kNumInstruments when adding or removing instruments");
+  static_assert(kNumInstruments == 12,
+                "Update kNumInstruments when adding or removing instruments");
 
-    s_instruments[0]  = meter->CreateInt64ObservableGauge("dust_mite.rssi",            "WiFi RSSI",      "dBm");
-    s_instruments[1]  = meter->CreateDoubleObservableGauge("dust_mite.speed",           "Car speed",      "km/h");
-    s_instruments[2]  = meter->CreateInt64ObservableGauge("dust_mite.distance_ahead",  "Ultrasonic distance", "cm");
-    s_instruments[3]  = meter->CreateDoubleObservableGauge("dust_mite.accelerometer.x", "Accelerometer X", "g");
-    s_instruments[4]  = meter->CreateDoubleObservableGauge("dust_mite.accelerometer.y", "Accelerometer Y", "g");
-    s_instruments[5]  = meter->CreateDoubleObservableGauge("dust_mite.accelerometer.z", "Accelerometer Z", "g");
-    s_instruments[6]  = meter->CreateDoubleObservableGauge("dust_mite.magnetometer.x",  "Magnetometer X",  "G");
-    s_instruments[7]  = meter->CreateDoubleObservableGauge("dust_mite.magnetometer.y",  "Magnetometer Y",  "G");
-    s_instruments[8]  = meter->CreateDoubleObservableGauge("dust_mite.magnetometer.z",  "Magnetometer Z",  "G");
-    s_instruments[9]  = meter->CreateDoubleObservableGauge("dust_mite.gyroscope.x",     "Gyroscope X",     "deg/s");
-    s_instruments[10] = meter->CreateDoubleObservableGauge("dust_mite.gyroscope.y",     "Gyroscope Y",     "deg/s");
-    s_instruments[11] = meter->CreateDoubleObservableGauge("dust_mite.gyroscope.z",     "Gyroscope Z",     "deg/s");
+  s_instruments[0] = meter->CreateInt64ObservableGauge("dust_mite.rssi", "WiFi RSSI", "dBm");
+  s_instruments[1] = meter->CreateDoubleObservableGauge("dust_mite.speed", "Car speed", "km/h");
+  s_instruments[2] =
+      meter->CreateInt64ObservableGauge("dust_mite.distance_ahead", "Ultrasonic distance", "cm");
+  s_instruments[3] =
+      meter->CreateDoubleObservableGauge("dust_mite.accelerometer.x", "Accelerometer X", "g");
+  s_instruments[4] =
+      meter->CreateDoubleObservableGauge("dust_mite.accelerometer.y", "Accelerometer Y", "g");
+  s_instruments[5] =
+      meter->CreateDoubleObservableGauge("dust_mite.accelerometer.z", "Accelerometer Z", "g");
+  s_instruments[6] =
+      meter->CreateDoubleObservableGauge("dust_mite.magnetometer.x", "Magnetometer X", "G");
+  s_instruments[7] =
+      meter->CreateDoubleObservableGauge("dust_mite.magnetometer.y", "Magnetometer Y", "G");
+  s_instruments[8] =
+      meter->CreateDoubleObservableGauge("dust_mite.magnetometer.z", "Magnetometer Z", "G");
+  s_instruments[9] =
+      meter->CreateDoubleObservableGauge("dust_mite.gyroscope.x", "Gyroscope X", "deg/s");
+  s_instruments[10] =
+      meter->CreateDoubleObservableGauge("dust_mite.gyroscope.y", "Gyroscope Y", "deg/s");
+  s_instruments[11] =
+      meter->CreateDoubleObservableGauge("dust_mite.gyroscope.z", "Gyroscope Z", "deg/s");
 
-    s_instruments[0] ->AddCallback(cb_rssi,           nullptr);
-    s_instruments[1] ->AddCallback(cb_speed,          nullptr);
-    s_instruments[2] ->AddCallback(cb_distance_ahead, nullptr);
-    s_instruments[3] ->AddCallback(cb_accel_x,        nullptr);
-    s_instruments[4] ->AddCallback(cb_accel_y,        nullptr);
-    s_instruments[5] ->AddCallback(cb_accel_z,        nullptr);
-    s_instruments[6] ->AddCallback(cb_mag_x,          nullptr);
-    s_instruments[7] ->AddCallback(cb_mag_y,          nullptr);
-    s_instruments[8] ->AddCallback(cb_mag_z,          nullptr);
-    s_instruments[9] ->AddCallback(cb_gyro_x,         nullptr);
-    s_instruments[10]->AddCallback(cb_gyro_y,         nullptr);
-    s_instruments[11]->AddCallback(cb_gyro_z,         nullptr);
+  s_instruments[0]->AddCallback(cb_rssi, nullptr);
+  s_instruments[1]->AddCallback(cb_speed, nullptr);
+  s_instruments[2]->AddCallback(cb_distance_ahead, nullptr);
+  s_instruments[3]->AddCallback(cb_accel_x, nullptr);
+  s_instruments[4]->AddCallback(cb_accel_y, nullptr);
+  s_instruments[5]->AddCallback(cb_accel_z, nullptr);
+  s_instruments[6]->AddCallback(cb_mag_x, nullptr);
+  s_instruments[7]->AddCallback(cb_mag_y, nullptr);
+  s_instruments[8]->AddCallback(cb_mag_z, nullptr);
+  s_instruments[9]->AddCallback(cb_gyro_x, nullptr);
+  s_instruments[10]->AddCallback(cb_gyro_y, nullptr);
+  s_instruments[11]->AddCallback(cb_gyro_z, nullptr);
 #endif
 }
 
 void telemetry_metrics_update(const telemetry_packet_t& packet) {
 #ifdef CONFIG_ESP_OPENTELEMETRY_METRICS_ENABLED
-    if (!s_mutex) return;
-    xSemaphoreTake(s_mutex, portMAX_DELAY);
-    s_state.rssi           = packet.rssi;
-    s_state.speed          = packet.speed;
-    s_state.distance_ahead = packet.distance_ahead;
-    s_state.accel_x        = packet.accelerometer.x;
-    s_state.accel_y        = packet.accelerometer.y;
-    s_state.accel_z        = packet.accelerometer.z;
-    s_state.mag_x          = packet.magnetometer.x;
-    s_state.mag_y          = packet.magnetometer.y;
-    s_state.mag_z          = packet.magnetometer.z;
-    s_state.gyro_x         = packet.gyroscope.x;
-    s_state.gyro_y         = packet.gyroscope.y;
-    s_state.gyro_z         = packet.gyroscope.z;
-    xSemaphoreGive(s_mutex);
+  if (!s_mutex) return;
+  xSemaphoreTake(s_mutex, portMAX_DELAY);
+  s_state.rssi = packet.rssi;
+  s_state.speed = packet.speed;
+  s_state.distance_ahead = packet.distance_ahead;
+  s_state.accel_x = packet.accelerometer.x;
+  s_state.accel_y = packet.accelerometer.y;
+  s_state.accel_z = packet.accelerometer.z;
+  s_state.mag_x = packet.magnetometer.x;
+  s_state.mag_y = packet.magnetometer.y;
+  s_state.mag_z = packet.magnetometer.z;
+  s_state.gyro_x = packet.gyroscope.x;
+  s_state.gyro_y = packet.gyroscope.y;
+  s_state.gyro_z = packet.gyroscope.z;
+  xSemaphoreGive(s_mutex);
 #endif
 }

--- a/car/components/telemetry/test_apps/main/main.cpp
+++ b/car/components/telemetry/test_apps/main/main.cpp
@@ -3,24 +3,23 @@
 #include "driver/gpio.h"
 #include "sdkconfig.h"
 
-extern "C" void app_main(void)
-{
+extern "C" void app_main(void) {
 #ifndef CONFIG_TELEMETRY_TEST_QEMU_MODE
-    i2c_master_bus_config_t bus_cfg = {};
-    bus_cfg.i2c_port = I2C_NUM_0;
-    bus_cfg.sda_io_num = GPIO_NUM_1;
-    bus_cfg.scl_io_num = GPIO_NUM_2;
-    bus_cfg.clk_source = I2C_CLK_SRC_DEFAULT;
-    bus_cfg.glitch_ignore_cnt = 7;
-    bus_cfg.flags.enable_internal_pullup = true;
-    i2c_master_bus_handle_t i2c_bus;
-    ESP_ERROR_CHECK(i2c_new_master_bus(&bus_cfg, &i2c_bus));
-    telemetry_init(i2c_bus);
+  i2c_master_bus_config_t bus_cfg = {};
+  bus_cfg.i2c_port = I2C_NUM_0;
+  bus_cfg.sda_io_num = GPIO_NUM_1;
+  bus_cfg.scl_io_num = GPIO_NUM_2;
+  bus_cfg.clk_source = I2C_CLK_SRC_DEFAULT;
+  bus_cfg.glitch_ignore_cnt = 7;
+  bus_cfg.flags.enable_internal_pullup = true;
+  i2c_master_bus_handle_t i2c_bus;
+  ESP_ERROR_CHECK(i2c_new_master_bus(&bus_cfg, &i2c_bus));
+  telemetry_init(i2c_bus);
 #endif
 
-    UNITY_BEGIN();
-    unity_run_all_tests();
-    UNITY_END();
+  UNITY_BEGIN();
+  unity_run_all_tests();
+  UNITY_END();
 }
 
 void setUp(void) {}

--- a/car/components/telemetry/test_apps/main/test_telemetry.cpp
+++ b/car/components/telemetry/test_apps/main/test_telemetry.cpp
@@ -2,34 +2,25 @@
 #include "unity.h"
 #include <math.h>
 
-TEST_CASE("speed", "[pcnt]")
-{
-    TEST_ASSERT_GREATER_OR_EQUAL_FLOAT(0.0f, get_speed());
+TEST_CASE("speed", "[pcnt]") { TEST_ASSERT_GREATER_OR_EQUAL_FLOAT(0.0f, get_speed()); }
+
+TEST_CASE("accelerometer", "[imu]") {
+  vector3_t d = read_accelerometer();
+  float mag = sqrtf(d.x * d.x + d.y * d.y + d.z * d.z);
+  TEST_ASSERT_FLOAT_WITHIN(0.5f, 1.0f, mag);
 }
 
-TEST_CASE("accelerometer", "[imu]")
-{
-    vector3_t d = read_accelerometer();
-    float mag = sqrtf(d.x * d.x + d.y * d.y + d.z * d.z);
-    TEST_ASSERT_FLOAT_WITHIN(0.5f, 1.0f, mag);
+TEST_CASE("magnetometer", "[imu]") {
+  vector3_t d = read_magnetometer();
+  float mag = sqrtf(d.x * d.x + d.y * d.y + d.z * d.z);
+  TEST_ASSERT_GREATER_THAN_FLOAT(0.0f, mag);
 }
 
-TEST_CASE("magnetometer", "[imu]")
-{
-    vector3_t d = read_magnetometer();
-    float mag = sqrtf(d.x * d.x + d.y * d.y + d.z * d.z);
-    TEST_ASSERT_GREATER_THAN_FLOAT(0.0f, mag);
+TEST_CASE("gyroscope", "[imu]") {
+  vector3_t d = read_gyroscope();
+  TEST_ASSERT_FLOAT_WITHIN(5.0f, 0.0f, d.x);
+  TEST_ASSERT_FLOAT_WITHIN(5.0f, 0.0f, d.y);
+  TEST_ASSERT_FLOAT_WITHIN(5.0f, 0.0f, d.z);
 }
 
-TEST_CASE("gyroscope", "[imu]")
-{
-    vector3_t d = read_gyroscope();
-    TEST_ASSERT_FLOAT_WITHIN(5.0f, 0.0f, d.x);
-    TEST_ASSERT_FLOAT_WITHIN(5.0f, 0.0f, d.y);
-    TEST_ASSERT_FLOAT_WITHIN(5.0f, 0.0f, d.z);
-}
-
-TEST_CASE("distance", "[urm]")
-{
-    TEST_ASSERT_GREATER_THAN(0, get_distance_ahead());
-}
+TEST_CASE("distance", "[urm]") { TEST_ASSERT_GREATER_THAN(0, get_distance_ahead()); }

--- a/car/components/telemetry/test_apps/main/test_telemetry_json.cpp
+++ b/car/components/telemetry/test_apps/main/test_telemetry_json.cpp
@@ -1,57 +1,49 @@
 #include "telemetry_types.hpp"
 #include "unity.h"
 
-TEST_CASE("json_schema_completeness", "[telemetry_json]")
-{
-    telemetry_packet_t p = {"2024-01-15T10:30:00Z", -65, 2.5f,
-                            {0.01f, 0.02f, 1.0f},
-                            {0.1f, -0.2f, 0.05f},
-                            {0.5f, -0.3f, 0.1f},
-                            100};
+TEST_CASE("json_schema_completeness", "[telemetry_json]") {
+  telemetry_packet_t p = {
+      "2024-01-15T10:30:00Z", -65, 2.5f, {0.01f, 0.02f, 1.0f}, {0.1f, -0.2f, 0.05f},
+      {0.5f, -0.3f, 0.1f},    100};
 
-    cJSON *j = convert_telemetry_packet_to_json(p);
-    TEST_ASSERT_NOT_NULL(j);
+  cJSON* j = convert_telemetry_packet_to_json(p);
+  TEST_ASSERT_NOT_NULL(j);
 
-    TEST_ASSERT_TRUE(cJSON_IsString(cJSON_GetObjectItem(j, "timestamp")));
-    TEST_ASSERT_TRUE(cJSON_IsNumber(cJSON_GetObjectItem(j, "rssi")));
-    TEST_ASSERT_TRUE(cJSON_IsNumber(cJSON_GetObjectItem(j, "speed")));
-    TEST_ASSERT_TRUE(cJSON_IsNumber(cJSON_GetObjectItem(j, "distance_ahead")));
+  TEST_ASSERT_TRUE(cJSON_IsString(cJSON_GetObjectItem(j, "timestamp")));
+  TEST_ASSERT_TRUE(cJSON_IsNumber(cJSON_GetObjectItem(j, "rssi")));
+  TEST_ASSERT_TRUE(cJSON_IsNumber(cJSON_GetObjectItem(j, "speed")));
+  TEST_ASSERT_TRUE(cJSON_IsNumber(cJSON_GetObjectItem(j, "distance_ahead")));
 
-    const char *vector_keys[] = {"accelerometer", "magnetometer", "gyroscope"};
-    for (int i = 0; i < 3; i++) {
-        const cJSON *obj = cJSON_GetObjectItem(j, vector_keys[i]);
-        TEST_ASSERT_NOT_NULL(obj);
-        TEST_ASSERT_TRUE(cJSON_IsNumber(cJSON_GetObjectItem(obj, "x")));
-        TEST_ASSERT_TRUE(cJSON_IsNumber(cJSON_GetObjectItem(obj, "y")));
-        TEST_ASSERT_TRUE(cJSON_IsNumber(cJSON_GetObjectItem(obj, "z")));
-    }
+  const char* vector_keys[] = {"accelerometer", "magnetometer", "gyroscope"};
+  for (int i = 0; i < 3; i++) {
+    const cJSON* obj = cJSON_GetObjectItem(j, vector_keys[i]);
+    TEST_ASSERT_NOT_NULL(obj);
+    TEST_ASSERT_TRUE(cJSON_IsNumber(cJSON_GetObjectItem(obj, "x")));
+    TEST_ASSERT_TRUE(cJSON_IsNumber(cJSON_GetObjectItem(obj, "y")));
+    TEST_ASSERT_TRUE(cJSON_IsNumber(cJSON_GetObjectItem(obj, "z")));
+  }
 
-    cJSON_Delete(j);
+  cJSON_Delete(j);
 }
 
-TEST_CASE("json_value_roundtrip", "[telemetry_json]")
-{
-    telemetry_packet_t p = {"2024-01-15T10:30:00Z", -65, 0.0f,
-                            {1.0f, 2.0f, 3.0f},
-                            {}, {}, 100};
+TEST_CASE("json_value_roundtrip", "[telemetry_json]") {
+  telemetry_packet_t p = {"2024-01-15T10:30:00Z", -65, 0.0f, {1.0f, 2.0f, 3.0f}, {}, {}, 100};
 
-    cJSON *j = convert_telemetry_packet_to_json(p);
-    TEST_ASSERT_NOT_NULL(j);
+  cJSON* j = convert_telemetry_packet_to_json(p);
+  TEST_ASSERT_NOT_NULL(j);
 
-    TEST_ASSERT_EQUAL_STRING("2024-01-15T10:30:00Z",
-        cJSON_GetStringValue(cJSON_GetObjectItem(j, "timestamp")));
-    TEST_ASSERT_EQUAL_INT(-65,
-        (int)cJSON_GetNumberValue(cJSON_GetObjectItem(j, "rssi")));
-    TEST_ASSERT_EQUAL_INT(100,
-        (int)cJSON_GetNumberValue(cJSON_GetObjectItem(j, "distance_ahead")));
+  TEST_ASSERT_EQUAL_STRING("2024-01-15T10:30:00Z",
+                           cJSON_GetStringValue(cJSON_GetObjectItem(j, "timestamp")));
+  TEST_ASSERT_EQUAL_INT(-65, (int)cJSON_GetNumberValue(cJSON_GetObjectItem(j, "rssi")));
+  TEST_ASSERT_EQUAL_INT(100, (int)cJSON_GetNumberValue(cJSON_GetObjectItem(j, "distance_ahead")));
 
-    const cJSON *accel = cJSON_GetObjectItem(j, "accelerometer");
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f,
-        (float)cJSON_GetNumberValue(cJSON_GetObjectItem(accel, "x")));
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 2.0f,
-        (float)cJSON_GetNumberValue(cJSON_GetObjectItem(accel, "y")));
-    TEST_ASSERT_FLOAT_WITHIN(0.001f, 3.0f,
-        (float)cJSON_GetNumberValue(cJSON_GetObjectItem(accel, "z")));
+  const cJSON* accel = cJSON_GetObjectItem(j, "accelerometer");
+  TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f,
+                           (float)cJSON_GetNumberValue(cJSON_GetObjectItem(accel, "x")));
+  TEST_ASSERT_FLOAT_WITHIN(0.001f, 2.0f,
+                           (float)cJSON_GetNumberValue(cJSON_GetObjectItem(accel, "y")));
+  TEST_ASSERT_FLOAT_WITHIN(0.001f, 3.0f,
+                           (float)cJSON_GetNumberValue(cJSON_GetObjectItem(accel, "z")));
 
-    cJSON_Delete(j);
+  cJSON_Delete(j);
 }

--- a/car/components/tracing/metrics.cpp
+++ b/car/components/tracing/metrics.cpp
@@ -25,59 +25,58 @@
 
 void observe_double(opentelemetry::metrics::ObserverResult& obs, double value) {
 #ifdef CONFIG_ESP_OPENTELEMETRY_METRICS_ENABLED
-    opentelemetry::nostd::get<
-        opentelemetry::nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<double>>>(obs)
-        ->Observe(value);
+  opentelemetry::nostd::get<
+      opentelemetry::nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<double>>>(obs)
+      ->Observe(value);
 #endif
 }
 
 void observe_int64(opentelemetry::metrics::ObserverResult& obs, int64_t value) {
 #ifdef CONFIG_ESP_OPENTELEMETRY_METRICS_ENABLED
-    opentelemetry::nostd::get<
-        opentelemetry::nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<int64_t>>>(obs)
-        ->Observe(value);
+  opentelemetry::nostd::get<
+      opentelemetry::nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<int64_t>>>(obs)
+      ->Observe(value);
 #endif
 }
 
 void metrics_setup() {
 #ifdef CONFIG_ESP_OPENTELEMETRY_METRICS_ENABLED
-    const char* metrics_base = CONFIG_ESP_OPENTELEMETRY_METRICS_OTLP_BASE_URL;
-    if (*metrics_base == '\0') metrics_base = CONFIG_ESP_OPENTELEMETRY_EXPORTER_OTLP_ENDPOINT;
-    std::string url = std::string(metrics_base) + "/v1/metrics";
+  const char* metrics_base = CONFIG_ESP_OPENTELEMETRY_METRICS_OTLP_BASE_URL;
+  if (*metrics_base == '\0') metrics_base = CONFIG_ESP_OPENTELEMETRY_EXPORTER_OTLP_ENDPOINT;
+  std::string url = std::string(metrics_base) + "/v1/metrics";
 
-    opentelemetry::exporter::otlp::OtlpHttpMetricExporterOptions opts;
-    opts.url = url;
-    auto exporter = opentelemetry::exporter::otlp::OtlpHttpMetricExporterFactory::Create(
-        opts, esp_opentelemetry::MakeEspHttpClient());
+  opentelemetry::exporter::otlp::OtlpHttpMetricExporterOptions opts;
+  opts.url = url;
+  auto exporter = opentelemetry::exporter::otlp::OtlpHttpMetricExporterFactory::Create(
+      opts, esp_opentelemetry::MakeEspHttpClient());
 
-    opentelemetry::sdk::metrics::PeriodicExportingMetricReaderOptions reader_opts;
-    reader_opts.export_interval_millis =
-        std::chrono::milliseconds(CONFIG_ESP_OPENTELEMETRY_METRICS_EXPORT_INTERVAL_MS);
-    reader_opts.export_timeout_millis =
-        std::chrono::milliseconds(CONFIG_ESP_OPENTELEMETRY_METRICS_EXPORT_INTERVAL_MS / 2);
+  opentelemetry::sdk::metrics::PeriodicExportingMetricReaderOptions reader_opts;
+  reader_opts.export_interval_millis =
+      std::chrono::milliseconds(CONFIG_ESP_OPENTELEMETRY_METRICS_EXPORT_INTERVAL_MS);
+  reader_opts.export_timeout_millis =
+      std::chrono::milliseconds(CONFIG_ESP_OPENTELEMETRY_METRICS_EXPORT_INTERVAL_MS / 2);
 
-    // The export thread (protobuf + mbedTLS) needs a large stack — route it to PSRAM.
-    esp_pthread_cfg_t orig_cfg = esp_pthread_get_default_config();
-    esp_pthread_cfg_t cfg      = orig_cfg;
-    cfg.stack_size             = 65536;
-    cfg.stack_alloc_caps       = MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT;
-    cfg.prio                   = 1;
-    esp_pthread_set_cfg(&cfg);
+  // The export thread (protobuf + mbedTLS) needs a large stack — route it to PSRAM.
+  esp_pthread_cfg_t orig_cfg = esp_pthread_get_default_config();
+  esp_pthread_cfg_t cfg = orig_cfg;
+  cfg.stack_size = 65536;
+  cfg.stack_alloc_caps = MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT;
+  cfg.prio = 1;
+  esp_pthread_set_cfg(&cfg);
 
-    auto reader = opentelemetry::sdk::metrics::PeriodicExportingMetricReaderFactory::Create(
-        std::move(exporter), reader_opts);
+  auto reader = opentelemetry::sdk::metrics::PeriodicExportingMetricReaderFactory::Create(
+      std::move(exporter), reader_opts);
 
-    auto resource = opentelemetry::sdk::resource::Resource::Create(
-        {{"service.name", CONFIG_ESP_OPENTELEMETRY_SERVICE_NAME}});
-    auto context = opentelemetry::sdk::metrics::MeterContextFactory::Create(
-        opentelemetry::sdk::metrics::ViewRegistryFactory::Create(), resource);
-    context->AddMetricReader(std::move(reader));
+  auto resource = opentelemetry::sdk::resource::Resource::Create(
+      {{"service.name", CONFIG_ESP_OPENTELEMETRY_SERVICE_NAME}});
+  auto context = opentelemetry::sdk::metrics::MeterContextFactory::Create(
+      opentelemetry::sdk::metrics::ViewRegistryFactory::Create(), resource);
+  context->AddMetricReader(std::move(reader));
 
-    esp_pthread_set_cfg(&orig_cfg);
+  esp_pthread_set_cfg(&orig_cfg);
 
-    auto sdk_provider =
-        opentelemetry::sdk::metrics::MeterProviderFactory::Create(std::move(context));
-    std::shared_ptr<opentelemetry::metrics::MeterProvider> api_provider = std::move(sdk_provider);
-    opentelemetry::sdk::metrics::Provider::SetMeterProvider(api_provider);
+  auto sdk_provider = opentelemetry::sdk::metrics::MeterProviderFactory::Create(std::move(context));
+  std::shared_ptr<opentelemetry::metrics::MeterProvider> api_provider = std::move(sdk_provider);
+  opentelemetry::sdk::metrics::Provider::SetMeterProvider(api_provider);
 #endif  // CONFIG_ESP_OPENTELEMETRY_METRICS_ENABLED
 }

--- a/car/components/tracing/system_metrics.cpp
+++ b/car/components/tracing/system_metrics.cpp
@@ -28,114 +28,113 @@ static temperature_sensor_handle_t s_temp_sensor = NULL;
 static constexpr UBaseType_t kMaxTasks = 48;
 
 struct TaskStat {
-    TaskHandle_t handle        = nullptr;
-    char         name[configMAX_TASK_NAME_LEN + 1] = {};
-    char         core[4]       = {};
-    uint32_t     prev_run_time = 0;
-    UBaseType_t  priority      = 0;
-    float        cpu_pct       = 0.0f;
+  TaskHandle_t handle = nullptr;
+  char name[configMAX_TASK_NAME_LEN + 1] = {};
+  char core[4] = {};
+  uint32_t prev_run_time = 0;
+  UBaseType_t priority = 0;
+  float cpu_pct = 0.0f;
 };
-static TaskStat    s_task_stats[kMaxTasks];
-static UBaseType_t s_task_count      = 0;
-static int64_t     s_prev_sample_time  = 0;
-static int64_t     s_last_refresh_time = 0;
+static TaskStat s_task_stats[kMaxTasks];
+static UBaseType_t s_task_count = 0;
+static int64_t s_prev_sample_time = 0;
+static int64_t s_last_refresh_time = 0;
 
 template <typename T>
-static void observe_task_metric(opentelemetry::metrics::ObserverResult& obs,
-                                T value, const char* task_name, const char* core) {
-    using Pair = std::pair<opentelemetry::nostd::string_view,
-                           opentelemetry::common::AttributeValue>;
-    std::array<Pair, 2> attrs{{
-        {"task", opentelemetry::nostd::string_view(task_name)},
-        {"core", opentelemetry::nostd::string_view(core)}
-    }};
-    opentelemetry::nostd::get<
-        opentelemetry::nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<T>>>(obs)
-        ->Observe(value, opentelemetry::common::KeyValueIterableView<std::array<Pair, 2>>(attrs));
+static void observe_task_metric(opentelemetry::metrics::ObserverResult& obs, T value,
+                                const char* task_name, const char* core) {
+  using Pair = std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue>;
+  std::array<Pair, 2> attrs{{{"task", opentelemetry::nostd::string_view(task_name)},
+                             {"core", opentelemetry::nostd::string_view(core)}}};
+  opentelemetry::nostd::get<
+      opentelemetry::nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<T>>>(obs)
+      ->Observe(value, opentelemetry::common::KeyValueIterableView<std::array<Pair, 2>>(attrs));
 }
 
 static void refresh_task_stats() {
-    int64_t now = esp_timer_get_time();
-    if (now - s_last_refresh_time < 100000LL) return;
+  int64_t now = esp_timer_get_time();
+  if (now - s_last_refresh_time < 100000LL) return;
 
-    static TaskStatus_t snap[kMaxTasks];
-    uint32_t dummy;
-    UBaseType_t n = uxTaskGetSystemState(snap, kMaxTasks, &dummy);
-    if (n == 0) return;
+  static TaskStatus_t snap[kMaxTasks];
+  uint32_t dummy;
+  UBaseType_t n = uxTaskGetSystemState(snap, kMaxTasks, &dummy);
+  if (n == 0) return;
 
-    s_last_refresh_time = now;
-    int64_t dt = now - s_prev_sample_time;
+  s_last_refresh_time = now;
+  int64_t dt = now - s_prev_sample_time;
 
-    for (UBaseType_t i = 0; i < n; i++) {
-        float pct = 0.0f;
-        if (s_prev_sample_time > 0 && dt > 0) {
-            for (UBaseType_t j = 0; j < s_task_count; j++) {
-                if (s_task_stats[j].handle == snap[i].xHandle) {
-                    uint32_t delta = snap[i].ulRunTimeCounter - s_task_stats[j].prev_run_time;
-                    pct = (static_cast<float>(delta) / static_cast<float>(dt)) * 100.0f;
-                    if (pct < 0.0f) pct = 0.0f;
-                    if (pct > 100.0f) pct = 100.0f;
-                    break;
-                }
-            }
+  for (UBaseType_t i = 0; i < n; i++) {
+    float pct = 0.0f;
+    if (s_prev_sample_time > 0 && dt > 0) {
+      for (UBaseType_t j = 0; j < s_task_count; j++) {
+        if (s_task_stats[j].handle == snap[i].xHandle) {
+          uint32_t delta = snap[i].ulRunTimeCounter - s_task_stats[j].prev_run_time;
+          pct = (static_cast<float>(delta) / static_cast<float>(dt)) * 100.0f;
+          if (pct < 0.0f) pct = 0.0f;
+          if (pct > 100.0f) pct = 100.0f;
+          break;
         }
-        BaseType_t core_id = xTaskGetCoreID(snap[i].xHandle);
-        if (core_id == tskNO_AFFINITY) {
-            s_task_stats[i].core[0] = 'a'; s_task_stats[i].core[1] = 'n';
-            s_task_stats[i].core[2] = 'y'; s_task_stats[i].core[3] = '\0';
-        } else {
-            s_task_stats[i].core[0] = '0' + static_cast<char>(core_id);
-            s_task_stats[i].core[1] = '\0';
-        }
-        s_task_stats[i].handle        = snap[i].xHandle;
-        strncpy(s_task_stats[i].name, snap[i].pcTaskName, configMAX_TASK_NAME_LEN);
-        s_task_stats[i].name[configMAX_TASK_NAME_LEN] = '\0';
-        s_task_stats[i].prev_run_time = snap[i].ulRunTimeCounter;
-        s_task_stats[i].priority      = snap[i].uxCurrentPriority;
-        s_task_stats[i].cpu_pct       = pct;
+      }
     }
-    s_task_count       = n;
-    s_prev_sample_time = now;
+    BaseType_t core_id = xTaskGetCoreID(snap[i].xHandle);
+    if (core_id == tskNO_AFFINITY) {
+      s_task_stats[i].core[0] = 'a';
+      s_task_stats[i].core[1] = 'n';
+      s_task_stats[i].core[2] = 'y';
+      s_task_stats[i].core[3] = '\0';
+    } else {
+      s_task_stats[i].core[0] = '0' + static_cast<char>(core_id);
+      s_task_stats[i].core[1] = '\0';
+    }
+    s_task_stats[i].handle = snap[i].xHandle;
+    strncpy(s_task_stats[i].name, snap[i].pcTaskName, configMAX_TASK_NAME_LEN);
+    s_task_stats[i].name[configMAX_TASK_NAME_LEN] = '\0';
+    s_task_stats[i].prev_run_time = snap[i].ulRunTimeCounter;
+    s_task_stats[i].priority = snap[i].uxCurrentPriority;
+    s_task_stats[i].cpu_pct = pct;
+  }
+  s_task_count = n;
+  s_prev_sample_time = now;
 }
 #endif  // CONFIG_ESP_OPENTELEMETRY_METRICS_TASK_STATS_ENABLED
 
 static void cb_free_heap(opentelemetry::metrics::ObserverResult obs, void*) {
-    observe_int64(obs, static_cast<int64_t>(esp_get_free_heap_size()));
+  observe_int64(obs, static_cast<int64_t>(esp_get_free_heap_size()));
 }
 static void cb_min_free_heap(opentelemetry::metrics::ObserverResult obs, void*) {
-    observe_int64(obs, static_cast<int64_t>(esp_get_minimum_free_heap_size()));
+  observe_int64(obs, static_cast<int64_t>(esp_get_minimum_free_heap_size()));
 }
 #ifdef CONFIG_ESP_OPENTELEMETRY_METRICS_LARGEST_FREE_BLOCK_ENABLED
 static void cb_largest_free_block(opentelemetry::metrics::ObserverResult obs, void*) {
-    observe_int64(obs, static_cast<int64_t>(heap_caps_get_largest_free_block(MALLOC_CAP_8BIT)));
+  observe_int64(obs, static_cast<int64_t>(heap_caps_get_largest_free_block(MALLOC_CAP_8BIT)));
 }
 #endif  // CONFIG_ESP_OPENTELEMETRY_METRICS_LARGEST_FREE_BLOCK_ENABLED
 static void cb_internal_free_heap(opentelemetry::metrics::ObserverResult obs, void*) {
-    observe_int64(obs, static_cast<int64_t>(esp_get_free_internal_heap_size()));
+  observe_int64(obs, static_cast<int64_t>(esp_get_free_internal_heap_size()));
 }
 static void cb_free_psram(opentelemetry::metrics::ObserverResult obs, void*) {
-    observe_int64(obs, static_cast<int64_t>(heap_caps_get_free_size(MALLOC_CAP_SPIRAM)));
+  observe_int64(obs, static_cast<int64_t>(heap_caps_get_free_size(MALLOC_CAP_SPIRAM)));
 }
 static void cb_uptime(opentelemetry::metrics::ObserverResult obs, void*) {
-    observe_double(obs, static_cast<double>(esp_timer_get_time()) / 1e6);
+  observe_double(obs, static_cast<double>(esp_timer_get_time()) / 1e6);
 }
 static void cb_temperature(opentelemetry::metrics::ObserverResult obs, void*) {
-    float temp = 0.0f;
-    if (s_temp_sensor) temperature_sensor_get_celsius(s_temp_sensor, &temp);
-    observe_double(obs, static_cast<double>(temp));
+  float temp = 0.0f;
+  if (s_temp_sensor) temperature_sensor_get_celsius(s_temp_sensor, &temp);
+  observe_double(obs, static_cast<double>(temp));
 }
 #ifdef CONFIG_ESP_OPENTELEMETRY_METRICS_TASK_STATS_ENABLED
 static void cb_task_cpu_usage(opentelemetry::metrics::ObserverResult obs, void*) {
-    refresh_task_stats();
-    for (UBaseType_t i = 0; i < s_task_count; i++)
-        observe_task_metric(obs, static_cast<double>(s_task_stats[i].cpu_pct),
-                            s_task_stats[i].name, s_task_stats[i].core);
+  refresh_task_stats();
+  for (UBaseType_t i = 0; i < s_task_count; i++)
+    observe_task_metric(obs, static_cast<double>(s_task_stats[i].cpu_pct), s_task_stats[i].name,
+                        s_task_stats[i].core);
 }
 static void cb_task_priority(opentelemetry::metrics::ObserverResult obs, void*) {
-    refresh_task_stats();
-    for (UBaseType_t i = 0; i < s_task_count; i++)
-        observe_task_metric(obs, static_cast<int64_t>(s_task_stats[i].priority),
-                            s_task_stats[i].name, s_task_stats[i].core);
+  refresh_task_stats();
+  for (UBaseType_t i = 0; i < s_task_count; i++)
+    observe_task_metric(obs, static_cast<int64_t>(s_task_stats[i].priority), s_task_stats[i].name,
+                        s_task_stats[i].core);
 }
 #endif  // CONFIG_ESP_OPENTELEMETRY_METRICS_TASK_STATS_ENABLED
 
@@ -155,62 +154,72 @@ static constexpr size_t kTaskStatsInstruments = 0;
 #endif
 static constexpr size_t kNumInstruments =
     kBaseInstruments + kLargestFreeBlockInstruments + kTaskStatsInstruments;
-static opentelemetry::nostd::shared_ptr<metrics_api::ObservableInstrument> s_instruments[kNumInstruments];
+static opentelemetry::nostd::shared_ptr<metrics_api::ObservableInstrument>
+    s_instruments[kNumInstruments];
 
 }  // namespace
 #endif  // CONFIG_ESP_OPENTELEMETRY_METRICS_ENABLED
 
 void system_metrics_setup() {
 #ifdef CONFIG_ESP_OPENTELEMETRY_METRICS_ENABLED
-    temperature_sensor_config_t temp_cfg = TEMPERATURE_SENSOR_CONFIG_DEFAULT(10, 80);
-    temperature_sensor_install(&temp_cfg, &s_temp_sensor);
-    temperature_sensor_enable(s_temp_sensor);
+  temperature_sensor_config_t temp_cfg = TEMPERATURE_SENSOR_CONFIG_DEFAULT(10, 80);
+  temperature_sensor_install(&temp_cfg, &s_temp_sensor);
+  temperature_sensor_enable(s_temp_sensor);
 
-    auto meter = metrics_api::Provider::GetMeterProvider()->GetMeter(
-        CONFIG_ESP_OPENTELEMETRY_SERVICE_NAME, "1.0.0");
+  auto meter = metrics_api::Provider::GetMeterProvider()->GetMeter(
+      CONFIG_ESP_OPENTELEMETRY_SERVICE_NAME, "1.0.0");
 
-    size_t idx = 0;
+  size_t idx = 0;
 
-    s_instruments[idx] = meter->CreateInt64ObservableGauge("dust_mite.free_heap_bytes",        "Free heap",                          "By");
-    s_instruments[idx]->AddCallback(cb_free_heap, nullptr);
-    idx++;
+  s_instruments[idx] =
+      meter->CreateInt64ObservableGauge("dust_mite.free_heap_bytes", "Free heap", "By");
+  s_instruments[idx]->AddCallback(cb_free_heap, nullptr);
+  idx++;
 
-    s_instruments[idx] = meter->CreateInt64ObservableGauge("dust_mite.min_free_heap_bytes",     "Min free heap since boot",           "By");
-    s_instruments[idx]->AddCallback(cb_min_free_heap, nullptr);
-    idx++;
+  s_instruments[idx] = meter->CreateInt64ObservableGauge("dust_mite.min_free_heap_bytes",
+                                                         "Min free heap since boot", "By");
+  s_instruments[idx]->AddCallback(cb_min_free_heap, nullptr);
+  idx++;
 
 #ifdef CONFIG_ESP_OPENTELEMETRY_METRICS_LARGEST_FREE_BLOCK_ENABLED
-    s_instruments[idx] = meter->CreateInt64ObservableGauge("dust_mite.largest_free_block_bytes", "Largest contiguous free heap block", "By");
-    s_instruments[idx]->AddCallback(cb_largest_free_block, nullptr);
-    idx++;
+  s_instruments[idx] = meter->CreateInt64ObservableGauge(
+      "dust_mite.largest_free_block_bytes", "Largest contiguous free heap block", "By");
+  s_instruments[idx]->AddCallback(cb_largest_free_block, nullptr);
+  idx++;
 #endif
 
-    s_instruments[idx] = meter->CreateInt64ObservableGauge("dust_mite.internal_free_heap_bytes", "Free internal SRAM heap",           "By");
-    s_instruments[idx]->AddCallback(cb_internal_free_heap, nullptr);
-    idx++;
+  s_instruments[idx] = meter->CreateInt64ObservableGauge("dust_mite.internal_free_heap_bytes",
+                                                         "Free internal SRAM heap", "By");
+  s_instruments[idx]->AddCallback(cb_internal_free_heap, nullptr);
+  idx++;
 
-    s_instruments[idx] = meter->CreateInt64ObservableGauge("dust_mite.free_psram_bytes",        "Free PSRAM",                         "By");
-    s_instruments[idx]->AddCallback(cb_free_psram, nullptr);
-    idx++;
+  s_instruments[idx] =
+      meter->CreateInt64ObservableGauge("dust_mite.free_psram_bytes", "Free PSRAM", "By");
+  s_instruments[idx]->AddCallback(cb_free_psram, nullptr);
+  idx++;
 
-    s_instruments[idx] = meter->CreateDoubleObservableGauge("dust_mite.uptime",                  "Uptime since boot",                  "s");
-    s_instruments[idx]->AddCallback(cb_uptime, nullptr);
-    idx++;
+  s_instruments[idx] =
+      meter->CreateDoubleObservableGauge("dust_mite.uptime", "Uptime since boot", "s");
+  s_instruments[idx]->AddCallback(cb_uptime, nullptr);
+  idx++;
 
-    s_instruments[idx] = meter->CreateDoubleObservableGauge("dust_mite.temperature",             "Die temperature",                    "Cel");
-    s_instruments[idx]->AddCallback(cb_temperature, nullptr);
-    idx++;
+  s_instruments[idx] =
+      meter->CreateDoubleObservableGauge("dust_mite.temperature", "Die temperature", "Cel");
+  s_instruments[idx]->AddCallback(cb_temperature, nullptr);
+  idx++;
 
 #ifdef CONFIG_ESP_OPENTELEMETRY_METRICS_TASK_STATS_ENABLED
-    s_instruments[idx] = meter->CreateDoubleObservableGauge("dust_mite.task_cpu_usage",          "Per-task CPU usage",                 "%");
-    s_instruments[idx]->AddCallback(cb_task_cpu_usage, nullptr);
-    idx++;
+  s_instruments[idx] =
+      meter->CreateDoubleObservableGauge("dust_mite.task_cpu_usage", "Per-task CPU usage", "%");
+  s_instruments[idx]->AddCallback(cb_task_cpu_usage, nullptr);
+  idx++;
 
-    s_instruments[idx] = meter->CreateInt64ObservableGauge("dust_mite.task_priority",            "Per-task FreeRTOS priority",         "1");
-    s_instruments[idx]->AddCallback(cb_task_priority, nullptr);
-    idx++;
+  s_instruments[idx] = meter->CreateInt64ObservableGauge("dust_mite.task_priority",
+                                                         "Per-task FreeRTOS priority", "1");
+  s_instruments[idx]->AddCallback(cb_task_priority, nullptr);
+  idx++;
 #endif
 
-    assert(idx == kNumInstruments);
+  assert(idx == kNumInstruments);
 #endif
 }

--- a/car/components/tracing/test_apps/main/test_tracing.cpp
+++ b/car/components/tracing/test_apps/main/test_tracing.cpp
@@ -11,142 +11,129 @@
 #include "opentelemetry/trace/span_context.h"
 #include "opentelemetry/trace/trace_flags.h"
 
-extern "C" void app_main(void)
-{
-    opentelemetry::context::propagation::GlobalTextMapPropagator::SetGlobalPropagator(
-        opentelemetry::nostd::shared_ptr<opentelemetry::context::propagation::TextMapPropagator>(
-            new opentelemetry::trace::propagation::HttpTraceContext()));
+extern "C" void app_main(void) {
+  opentelemetry::context::propagation::GlobalTextMapPropagator::SetGlobalPropagator(
+      opentelemetry::nostd::shared_ptr<opentelemetry::context::propagation::TextMapPropagator>(
+          new opentelemetry::trace::propagation::HttpTraceContext()));
 
-    UNITY_BEGIN();
-    unity_run_all_tests();
-    UNITY_END();
+  UNITY_BEGIN();
+  unity_run_all_tests();
+  UNITY_END();
 }
 
-const char traceparent[] =
-    "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+const char traceparent[] = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
 
 TEST_CASE("extract valid traceparent", "[tracing]") {
-    cJSON *obj = cJSON_CreateObject();
-    cJSON_AddStringToObject(obj, "traceparent", traceparent);
+  cJSON* obj = cJSON_CreateObject();
+  cJSON_AddStringToObject(obj, "traceparent", traceparent);
 
-    opentelemetry::context::Context ctx = tracing_extract(*obj);
-    cJSON_Delete(obj);
+  opentelemetry::context::Context ctx = tracing_extract(*obj);
+  cJSON_Delete(obj);
 
-    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span =
-        opentelemetry::trace::GetSpan(ctx);
-    opentelemetry::trace::SpanContext sc = span->GetContext();
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span =
+      opentelemetry::trace::GetSpan(ctx);
+  opentelemetry::trace::SpanContext sc = span->GetContext();
 
-    TEST_ASSERT_TRUE(sc.IsValid());
+  TEST_ASSERT_TRUE(sc.IsValid());
 
-    char trace_buf[33] = {};
-    sc.trace_id().ToLowerBase16({trace_buf, 32});
-    TEST_ASSERT_EQUAL_STRING("4bf92f3577b34da6a3ce929d0e0e4736", trace_buf);
+  char trace_buf[33] = {};
+  sc.trace_id().ToLowerBase16({trace_buf, 32});
+  TEST_ASSERT_EQUAL_STRING("4bf92f3577b34da6a3ce929d0e0e4736", trace_buf);
 
-    char span_buf[17] = {};
-    sc.span_id().ToLowerBase16({span_buf, 16});
-    TEST_ASSERT_EQUAL_STRING("00f067aa0ba902b7", span_buf);
+  char span_buf[17] = {};
+  sc.span_id().ToLowerBase16({span_buf, 16});
+  TEST_ASSERT_EQUAL_STRING("00f067aa0ba902b7", span_buf);
 
-    TEST_ASSERT_TRUE(sc.trace_flags().IsSampled());
+  TEST_ASSERT_TRUE(sc.trace_flags().IsSampled());
 }
 
 TEST_CASE("extract missing traceparent key", "[tracing]") {
-    cJSON *obj = cJSON_CreateObject();
+  cJSON* obj = cJSON_CreateObject();
 
-    opentelemetry::context::Context ctx = tracing_extract(*obj);
-    cJSON_Delete(obj);
+  opentelemetry::context::Context ctx = tracing_extract(*obj);
+  cJSON_Delete(obj);
 
-    opentelemetry::trace::SpanContext sc =
-        opentelemetry::trace::GetSpan(ctx)->GetContext();
-    TEST_ASSERT_FALSE(sc.IsValid());
+  opentelemetry::trace::SpanContext sc = opentelemetry::trace::GetSpan(ctx)->GetContext();
+  TEST_ASSERT_FALSE(sc.IsValid());
 }
 
 TEST_CASE("extract null traceparent value", "[tracing]") {
-    cJSON *obj = cJSON_CreateObject();
-    cJSON_AddNullToObject(obj, "traceparent");
+  cJSON* obj = cJSON_CreateObject();
+  cJSON_AddNullToObject(obj, "traceparent");
 
-    opentelemetry::context::Context ctx = tracing_extract(*obj);
-    cJSON_Delete(obj);
+  opentelemetry::context::Context ctx = tracing_extract(*obj);
+  cJSON_Delete(obj);
 
-    opentelemetry::trace::SpanContext sc =
-        opentelemetry::trace::GetSpan(ctx)->GetContext();
-    TEST_ASSERT_FALSE(sc.IsValid());
+  opentelemetry::trace::SpanContext sc = opentelemetry::trace::GetSpan(ctx)->GetContext();
+  TEST_ASSERT_FALSE(sc.IsValid());
 }
 
 TEST_CASE("extract non-string traceparent value", "[tracing]") {
-    cJSON *obj = cJSON_CreateObject();
-    cJSON_AddNumberToObject(obj, "traceparent", 42);
+  cJSON* obj = cJSON_CreateObject();
+  cJSON_AddNumberToObject(obj, "traceparent", 42);
 
-    opentelemetry::context::Context ctx = tracing_extract(*obj);
-    cJSON_Delete(obj);
+  opentelemetry::context::Context ctx = tracing_extract(*obj);
+  cJSON_Delete(obj);
 
-    opentelemetry::trace::SpanContext sc =
-        opentelemetry::trace::GetSpan(ctx)->GetContext();
-    TEST_ASSERT_FALSE(sc.IsValid());
+  opentelemetry::trace::SpanContext sc = opentelemetry::trace::GetSpan(ctx)->GetContext();
+  TEST_ASSERT_FALSE(sc.IsValid());
 }
 
 TEST_CASE("inject with no active span", "[tracing]") {
-    cJSON *obj = cJSON_CreateObject();
-    tracing_inject(*obj);
+  cJSON* obj = cJSON_CreateObject();
+  tracing_inject(*obj);
 
-    const cJSON *tp = cJSON_GetObjectItemCaseSensitive(obj, "traceparent");
-    cJSON_Delete(obj);
+  const cJSON* tp = cJSON_GetObjectItemCaseSensitive(obj, "traceparent");
+  cJSON_Delete(obj);
 
-    TEST_ASSERT_NULL(tp);
+  TEST_ASSERT_NULL(tp);
 }
 
 TEST_CASE("inject with valid span", "[tracing]") {
-    const uint8_t trace_bytes[16] = {0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3,
-                                          0x4d, 0xa6, 0xa3, 0xce, 0x92, 0x9d,
-                                          0x0e, 0x0e, 0x47, 0x36};
-    const uint8_t span_bytes[8] = {0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9,
-                                        0x02, 0xb7};
+  const uint8_t trace_bytes[16] = {0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6,
+                                   0xa3, 0xce, 0x92, 0x9d, 0x0e, 0x0e, 0x47, 0x36};
+  const uint8_t span_bytes[8] = {0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7};
 
-    opentelemetry::trace::SpanContext sc(
-        opentelemetry::trace::TraceId(trace_bytes),
-        opentelemetry::trace::SpanId(span_bytes),
-        opentelemetry::trace::TraceFlags(
-            opentelemetry::trace::TraceFlags::kIsSampled),
-        false
-    );
+  opentelemetry::trace::SpanContext sc(
+      opentelemetry::trace::TraceId(trace_bytes), opentelemetry::trace::SpanId(span_bytes),
+      opentelemetry::trace::TraceFlags(opentelemetry::trace::TraceFlags::kIsSampled), false);
 
-    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span(
-        new opentelemetry::trace::DefaultSpan(sc));
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span(
+      new opentelemetry::trace::DefaultSpan(sc));
 
-    opentelemetry::context::Context current =
-        opentelemetry::context::RuntimeContext::GetCurrent();
-    opentelemetry::context::Context ctx_with_span =
-        opentelemetry::trace::SetSpan(current, span);
-    opentelemetry::nostd::unique_ptr<opentelemetry::context::Token> token =
-        opentelemetry::context::RuntimeContext::Attach(ctx_with_span);
+  opentelemetry::context::Context current = opentelemetry::context::RuntimeContext::GetCurrent();
+  opentelemetry::context::Context ctx_with_span = opentelemetry::trace::SetSpan(current, span);
+  opentelemetry::nostd::unique_ptr<opentelemetry::context::Token> token =
+      opentelemetry::context::RuntimeContext::Attach(ctx_with_span);
 
-    cJSON *obj = cJSON_CreateObject();
-    tracing_inject(*obj);
+  cJSON* obj = cJSON_CreateObject();
+  tracing_inject(*obj);
 
-    const cJSON *tp = cJSON_GetObjectItemCaseSensitive(obj, "traceparent");
-    TEST_ASSERT_NOT_NULL(tp);
-    TEST_ASSERT_TRUE(cJSON_IsString(tp));
-    TEST_ASSERT_EQUAL_STRING(traceparent, tp->valuestring);
+  const cJSON* tp = cJSON_GetObjectItemCaseSensitive(obj, "traceparent");
+  TEST_ASSERT_NOT_NULL(tp);
+  TEST_ASSERT_TRUE(cJSON_IsString(tp));
+  TEST_ASSERT_EQUAL_STRING(traceparent, tp->valuestring);
 
-    cJSON_Delete(obj);
+  cJSON_Delete(obj);
 }
 
 TEST_CASE("inject extract roundtrip", "[tracing]") {
-    cJSON *in = cJSON_CreateObject();
-    cJSON_AddStringToObject(in, "traceparent", traceparent);
+  cJSON* in = cJSON_CreateObject();
+  cJSON_AddStringToObject(in, "traceparent", traceparent);
 
-    opentelemetry::context::Context ctx = tracing_extract(*in);
-    cJSON_Delete(in);
+  opentelemetry::context::Context ctx = tracing_extract(*in);
+  cJSON_Delete(in);
 
-    opentelemetry::nostd::unique_ptr<opentelemetry::context::Token> token =
-        opentelemetry::context::RuntimeContext::Attach(ctx);
+  opentelemetry::nostd::unique_ptr<opentelemetry::context::Token> token =
+      opentelemetry::context::RuntimeContext::Attach(ctx);
 
-    cJSON *out = cJSON_CreateObject();
-    tracing_inject(*out);
+  cJSON* out = cJSON_CreateObject();
+  tracing_inject(*out);
 
-    const cJSON *tp = cJSON_GetObjectItemCaseSensitive(out, "traceparent");
-    TEST_ASSERT_NOT_NULL(tp);
-    TEST_ASSERT_TRUE(cJSON_IsString(tp));
-    TEST_ASSERT_EQUAL_STRING(traceparent, tp->valuestring);
+  const cJSON* tp = cJSON_GetObjectItemCaseSensitive(out, "traceparent");
+  TEST_ASSERT_NOT_NULL(tp);
+  TEST_ASSERT_TRUE(cJSON_IsString(tp));
+  TEST_ASSERT_EQUAL_STRING(traceparent, tp->valuestring);
 
-    cJSON_Delete(out);
+  cJSON_Delete(out);
 }

--- a/car/components/tracing/tracing.cpp
+++ b/car/components/tracing/tracing.cpp
@@ -11,17 +11,15 @@
 
 namespace {
 
-class CJsonCarrier
-    : public opentelemetry::context::propagation::TextMapCarrier {
-public:
+class CJsonCarrier : public opentelemetry::context::propagation::TextMapCarrier {
+ public:
   explicit CJsonCarrier(cJSON& obj) : obj_(obj) {}
 
   opentelemetry::nostd::string_view Get(
       opentelemetry::nostd::string_view key) const noexcept override {
     std::string k(key.data(), key.size());
     const cJSON* item = cJSON_GetObjectItemCaseSensitive(&obj_, k.c_str());
-    if (item == nullptr || !cJSON_IsString(item) ||
-        item->valuestring == nullptr) {
+    if (item == nullptr || !cJSON_IsString(item) || item->valuestring == nullptr) {
       return {};
     }
     return opentelemetry::nostd::string_view(item->valuestring);
@@ -35,7 +33,7 @@ public:
     cJSON_AddStringToObject(&obj_, k.c_str(), v.c_str());
   }
 
-private:
+ private:
   cJSON& obj_;
 };
 
@@ -62,8 +60,7 @@ void tracing_setup() {
 
 void tracing_inject(cJSON& obj) {
   auto propagator =
-      opentelemetry::context::propagation::GlobalTextMapPropagator::
-          GetGlobalPropagator();
+      opentelemetry::context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
   if (!propagator) {
     return;
   }
@@ -75,8 +72,7 @@ void tracing_inject(cJSON& obj) {
 opentelemetry::context::Context tracing_extract(const cJSON& obj) {
   auto current = opentelemetry::context::RuntimeContext::GetCurrent();
   auto propagator =
-      opentelemetry::context::propagation::GlobalTextMapPropagator::
-          GetGlobalPropagator();
+      opentelemetry::context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
   if (!propagator) {
     return current;
   }

--- a/car/components/web_server/command_parser.cpp
+++ b/car/components/web_server/command_parser.cpp
@@ -2,14 +2,14 @@
 #include "motor.hpp"
 #include <cJSON.h>
 
-bool parse_command_packet(const char *json, command_packet_t *out) {
-    if (!json || !out) return false;
-    cJSON *root = cJSON_Parse(json);
-    if (!root) return false;
-    cJSON *cmd_obj = cJSON_GetObjectItem(root, "command");
-    cJSON *val_obj = cJSON_GetObjectItem(root, "value");
-    out->command = cJSON_IsNumber(cmd_obj) ? (char)cJSON_GetNumberValue(cmd_obj) : 0;
-    out->value   = cJSON_IsNumber(val_obj) ? (int)cJSON_GetNumberValue(val_obj) : 0;
-    cJSON_Delete(root);
-    return true;
+bool parse_command_packet(const char* json, command_packet_t* out) {
+  if (!json || !out) return false;
+  cJSON* root = cJSON_Parse(json);
+  if (!root) return false;
+  cJSON* cmd_obj = cJSON_GetObjectItem(root, "command");
+  cJSON* val_obj = cJSON_GetObjectItem(root, "value");
+  out->command = cJSON_IsNumber(cmd_obj) ? (char)cJSON_GetNumberValue(cmd_obj) : 0;
+  out->value = cJSON_IsNumber(val_obj) ? (int)cJSON_GetNumberValue(val_obj) : 0;
+  cJSON_Delete(root);
+  return true;
 }

--- a/car/components/web_server/include/web_server.hpp
+++ b/car/components/web_server/include/web_server.hpp
@@ -8,9 +8,10 @@ extern "C" {
 #include "freertos/queue.h"
 #include "motor.hpp"
 
-void web_server_setup(QueueHandle_t frame_queue, QueueHandle_t command_queue, QueueHandle_t telemetry_queue);
+void web_server_setup(QueueHandle_t frame_queue, QueueHandle_t command_queue,
+                      QueueHandle_t telemetry_queue);
 
-bool parse_command_packet(const char *json, command_packet_t *out);
+bool parse_command_packet(const char* json, command_packet_t* out);
 
 #ifdef __cplusplus
 }

--- a/car/components/web_server/test_apps/main/main.cpp
+++ b/car/components/web_server/test_apps/main/main.cpp
@@ -8,22 +8,21 @@
 #include "unity.h"
 #include "sdkconfig.h"
 
-extern "C" void app_main(void)
-{
-    QueueHandle_t command_queue   = xQueueCreate(2, sizeof(command_packet_t));
-    QueueHandle_t frame_queue     = xQueueCreate(2, sizeof(void*));
-    QueueHandle_t telemetry_queue = xQueueCreate(2, sizeof(telemetry_packet_t));
+extern "C" void app_main(void) {
+  QueueHandle_t command_queue = xQueueCreate(2, sizeof(command_packet_t));
+  QueueHandle_t frame_queue = xQueueCreate(2, sizeof(void*));
+  QueueHandle_t telemetry_queue = xQueueCreate(2, sizeof(telemetry_packet_t));
 
 #ifndef CONFIG_WEB_SERVER_TEST_QEMU_MODE
-    motor_setup(command_queue);
-    tracing_setup();
-    wifi_setup();
-    web_server_setup(frame_queue, command_queue, telemetry_queue);
+  motor_setup(command_queue);
+  tracing_setup();
+  wifi_setup();
+  web_server_setup(frame_queue, command_queue, telemetry_queue);
 #endif
 
-    UNITY_BEGIN();
-    unity_run_all_tests();
-    UNITY_END();
+  UNITY_BEGIN();
+  unity_run_all_tests();
+  UNITY_END();
 }
 
 void setUp(void) {}

--- a/car/components/web_server/test_apps/main/test_command_parser.cpp
+++ b/car/components/web_server/test_apps/main/test_command_parser.cpp
@@ -1,40 +1,35 @@
 #include "web_server.hpp"
 #include "unity.h"
 
-TEST_CASE("parse_valid_command_and_value", "[web_server]")
-{
-    command_packet_t p = {};
-    TEST_ASSERT_TRUE(parse_command_packet("{\"command\":3,\"value\":50}", &p));
-    TEST_ASSERT_EQUAL_INT(3, p.command);
-    TEST_ASSERT_EQUAL_INT(50, p.value);
+TEST_CASE("parse_valid_command_and_value", "[web_server]") {
+  command_packet_t p = {};
+  TEST_ASSERT_TRUE(parse_command_packet("{\"command\":3,\"value\":50}", &p));
+  TEST_ASSERT_EQUAL_INT(3, p.command);
+  TEST_ASSERT_EQUAL_INT(50, p.value);
 }
 
-TEST_CASE("parse_missing_value_defaults_zero", "[web_server]")
-{
-    command_packet_t p = {};
-    TEST_ASSERT_TRUE(parse_command_packet("{\"command\":2}", &p));
-    TEST_ASSERT_EQUAL_INT(2, p.command);
-    TEST_ASSERT_EQUAL_INT(0, p.value);
+TEST_CASE("parse_missing_value_defaults_zero", "[web_server]") {
+  command_packet_t p = {};
+  TEST_ASSERT_TRUE(parse_command_packet("{\"command\":2}", &p));
+  TEST_ASSERT_EQUAL_INT(2, p.command);
+  TEST_ASSERT_EQUAL_INT(0, p.value);
 }
 
-TEST_CASE("parse_missing_command_field", "[web_server]")
-{
-    // cJSON_GetNumberValue(NULL) returns 0.0, so command=0 (out of valid range 1-7).
-    // This test pins the current behavior; a future fix to reject it would change the assertion.
-    command_packet_t p = {};
-    TEST_ASSERT_TRUE(parse_command_packet("{\"value\":50}", &p));
-    TEST_ASSERT_EQUAL_INT(0, p.command);
-    TEST_ASSERT_EQUAL_INT(50, p.value);
+TEST_CASE("parse_missing_command_field", "[web_server]") {
+  // cJSON_GetNumberValue(NULL) returns 0.0, so command=0 (out of valid range 1-7).
+  // This test pins the current behavior; a future fix to reject it would change the assertion.
+  command_packet_t p = {};
+  TEST_ASSERT_TRUE(parse_command_packet("{\"value\":50}", &p));
+  TEST_ASSERT_EQUAL_INT(0, p.command);
+  TEST_ASSERT_EQUAL_INT(50, p.value);
 }
 
-TEST_CASE("parse_malformed_json", "[web_server]")
-{
-    command_packet_t p = {};
-    TEST_ASSERT_FALSE(parse_command_packet("{not json}", &p));
+TEST_CASE("parse_malformed_json", "[web_server]") {
+  command_packet_t p = {};
+  TEST_ASSERT_FALSE(parse_command_packet("{not json}", &p));
 }
 
-TEST_CASE("parse_null_input", "[web_server]")
-{
-    command_packet_t p = {};
-    TEST_ASSERT_FALSE(parse_command_packet(nullptr, &p));
+TEST_CASE("parse_null_input", "[web_server]") {
+  command_packet_t p = {};
+  TEST_ASSERT_FALSE(parse_command_packet(nullptr, &p));
 }

--- a/car/components/web_server/web_server.cpp
+++ b/car/components/web_server/web_server.cpp
@@ -45,7 +45,7 @@ static TaskHandle_t g_telemetry_task_handle = NULL;
 static opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> g_stream_connection_span;
 static opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> g_telemetry_connection_span;
 
-static esp_err_t root_get_handler(httpd_req_t *req) {
+static esp_err_t root_get_handler(httpd_req_t* req) {
   esp_err_t ret = ESP_OK;
 
   if (req->method == HTTP_GET) {
@@ -66,9 +66,9 @@ static esp_err_t root_get_handler(httpd_req_t *req) {
     return ESP_FAIL;
   }
 
-  unsigned char *buf = NULL;
+  unsigned char* buf = NULL;
   if (ws_pkt.len > 0) {
-    buf = (unsigned char *)malloc(ws_pkt.len + 1);
+    buf = (unsigned char*)malloc(ws_pkt.len + 1);
     buf[ws_pkt.len] = '\0';
   }
 
@@ -82,34 +82,34 @@ static esp_err_t root_get_handler(httpd_req_t *req) {
 
   command_packet_t packet = {};
   if (parse_command_packet((const char*)ws_pkt.payload, &packet)) {
-      ESP_LOGI(TAG, "JSON={\"command\": %d, \"value\": %d}", packet.command, packet.value);
+    ESP_LOGI(TAG, "JSON={\"command\": %d, \"value\": %d}", packet.command, packet.value);
 
-      cJSON *root = cJSON_Parse((const char*)ws_pkt.payload);
-      auto parent_ctx = tracing_extract(*root);
-      cJSON_Delete(root);
+    cJSON* root = cJSON_Parse((const char*)ws_pkt.payload);
+    auto parent_ctx = tracing_extract(*root);
+    cJSON_Delete(root);
 
-      opentelemetry::trace::StartSpanOptions start_opts;
-      start_opts.kind   = opentelemetry::trace::SpanKind::kServer;
-      start_opts.parent = opentelemetry::trace::GetSpan(parent_ctx)->GetContext();
-      auto span = esp_opentelemetry_tracer()->StartSpan(
-          "ws.command.receive",
-          {{"ws.url", "/"},
-           {"network.protocol.name", "websocket"},
-           {"ws.message.type", "command"},
-           {"ws.message.size", static_cast<int64_t>(ws_pkt.len)},
-           {"command.name", static_cast<int64_t>(packet.command)},
-           {"command.value", static_cast<int64_t>(packet.value)}},
-          start_opts);
-      auto scope = opentelemetry::trace::Scope(span);
+    opentelemetry::trace::StartSpanOptions start_opts;
+    start_opts.kind = opentelemetry::trace::SpanKind::kServer;
+    start_opts.parent = opentelemetry::trace::GetSpan(parent_ctx)->GetContext();
+    auto span = esp_opentelemetry_tracer()->StartSpan(
+        "ws.command.receive",
+        {{"ws.url", "/"},
+         {"network.protocol.name", "websocket"},
+         {"ws.message.type", "command"},
+         {"ws.message.size", static_cast<int64_t>(ws_pkt.len)},
+         {"command.name", static_cast<int64_t>(packet.command)},
+         {"command.value", static_cast<int64_t>(packet.value)}},
+        start_opts);
+    auto scope = opentelemetry::trace::Scope(span);
 
-      if (xQueueSendToBack(g_command_queue, &packet, portMAX_DELAY) != pdPASS) {
-        ESP_LOGE(TAG, "xQueueSendToBack failed");
-        span->SetStatus(opentelemetry::trace::StatusCode::kError, "queue send failed");
-        span->End();
-        free(buf);
-        return ESP_FAIL;
-      }
+    if (xQueueSendToBack(g_command_queue, &packet, portMAX_DELAY) != pdPASS) {
+      ESP_LOGE(TAG, "xQueueSendToBack failed");
+      span->SetStatus(opentelemetry::trace::StatusCode::kError, "queue send failed");
       span->End();
+      free(buf);
+      return ESP_FAIL;
+    }
+    span->End();
   } else {
     ESP_LOGW(TAG, "Failed to parse JSON: %s", ws_pkt.payload);
     auto span = esp_opentelemetry_tracer()->StartSpan("ws.command.receive");
@@ -123,17 +123,17 @@ static esp_err_t root_get_handler(httpd_req_t *req) {
 }
 
 static const httpd_uri_t root = {
-    .uri       = "/",
-    .method    = HTTP_GET,
-    .handler   = root_get_handler,
-    .user_ctx  = NULL,
+    .uri = "/",
+    .method = HTTP_GET,
+    .handler = root_get_handler,
+    .user_ctx = NULL,
     .is_websocket = true,
     .handle_ws_control_frames = false,
     .supported_subprotocol = NULL,
     .ws_post_handshake_cb = NULL,
 };
 
-static esp_err_t stream_handle_handshake(httpd_req_t *req) {
+static esp_err_t stream_handle_handshake(httpd_req_t* req) {
   if (g_server_task_handle == NULL) {
     g_server_task_handle = xTaskGetCurrentTaskHandle();
   }
@@ -141,9 +141,7 @@ static esp_err_t stream_handle_handshake(httpd_req_t *req) {
   opentelemetry::trace::StartSpanOptions stream_opts;
   stream_opts.kind = opentelemetry::trace::SpanKind::kServer;
   g_stream_connection_span = esp_opentelemetry_tracer()->StartSpan(
-      "ws.stream.connection",
-      {{"ws.url", "/stream"},
-       {"network.protocol.name", "websocket"}},
+      "ws.stream.connection", {{"ws.url", "/stream"}, {"network.protocol.name", "websocket"}},
       stream_opts);
   httpd_req_t* copy = NULL;
   esp_err_t ret = httpd_req_async_handler_begin(req, &copy);
@@ -164,7 +162,7 @@ static esp_err_t stream_handle_handshake(httpd_req_t *req) {
   return ESP_OK;
 }
 
-static esp_err_t stream_handle_websocket_frame(httpd_req_t *req) {
+static esp_err_t stream_handle_websocket_frame(httpd_req_t* req) {
   esp_err_t ret = ESP_OK;
 
   httpd_ws_frame_t ws_pkt = {};
@@ -175,9 +173,9 @@ static esp_err_t stream_handle_websocket_frame(httpd_req_t *req) {
     return ret;
   }
 
-  unsigned char *buf = NULL;
+  unsigned char* buf = NULL;
   if (ws_pkt.len > 0) {
-    buf = (unsigned char *)malloc(ws_pkt.len);
+    buf = (unsigned char*)malloc(ws_pkt.len);
   }
 
   ws_pkt.payload = buf;
@@ -195,8 +193,7 @@ static esp_err_t stream_handle_websocket_frame(httpd_req_t *req) {
     } else if (ws_pkt.type == HTTPD_WS_TYPE_CLOSE) {
       ESP_LOGI(TAG, "Got a WS CLOSE frame, Replying CLOSE");
       if (g_stream_connection_span) {
-        g_stream_connection_span->SetAttribute(
-            "ws.close.code", static_cast<int64_t>(ws_pkt.len));
+        g_stream_connection_span->SetAttribute("ws.close.code", static_cast<int64_t>(ws_pkt.len));
       }
       ws_pkt.len = 0;
       ws_pkt.payload = NULL;
@@ -220,8 +217,7 @@ static esp_err_t stream_handle_websocket_frame(httpd_req_t *req) {
   return ret;
 }
 
-static esp_err_t stream_get_handler(httpd_req_t *req)
-{
+static esp_err_t stream_get_handler(httpd_req_t* req) {
   if (g_server_task_handle == NULL) {
     g_server_task_handle = xTaskGetCurrentTaskHandle();
   }
@@ -289,13 +285,13 @@ void ws_stream_task(void* p) {
     opentelemetry::trace::StartSpanOptions send_opts;
     send_opts.kind = opentelemetry::trace::SpanKind::kProducer;
     send_opts.parent = g_stream_connection_span->GetContext();
-    auto send_span = esp_opentelemetry_tracer()->StartSpan(
-        "ws.stream.send",
-        {{"ws.url", "/stream"},
-         {"network.protocol.name", "websocket"},
-         {"ws.message.type", "stream"},
-         {"ws.frame.size", static_cast<int64_t>(frame->len)}},
-        send_opts);
+    auto send_span =
+        esp_opentelemetry_tracer()->StartSpan("ws.stream.send",
+                                              {{"ws.url", "/stream"},
+                                               {"network.protocol.name", "websocket"},
+                                               {"ws.message.type", "stream"},
+                                               {"ws.frame.size", static_cast<int64_t>(frame->len)}},
+                                              send_opts);
     auto send_scope = opentelemetry::trace::Scope(send_span);
 
     size_t b64_len = 0;
@@ -367,17 +363,17 @@ void ws_stream_task(void* p) {
 }
 
 static const httpd_uri_t stream = {
-    .uri       = "/stream",
-    .method    = HTTP_GET,
-    .handler   = stream_get_handler,
-    .user_ctx  = NULL,
+    .uri = "/stream",
+    .method = HTTP_GET,
+    .handler = stream_get_handler,
+    .user_ctx = NULL,
     .is_websocket = true,
     .handle_ws_control_frames = true,
     .supported_subprotocol = NULL,
     .ws_post_handshake_cb = stream_handle_handshake,
 };
 
-static esp_err_t telemetry_handle_handshake(httpd_req_t *req) {
+static esp_err_t telemetry_handle_handshake(httpd_req_t* req) {
   if (g_server_task_handle == NULL) {
     g_server_task_handle = xTaskGetCurrentTaskHandle();
   }
@@ -385,9 +381,7 @@ static esp_err_t telemetry_handle_handshake(httpd_req_t *req) {
   opentelemetry::trace::StartSpanOptions tel_opts;
   tel_opts.kind = opentelemetry::trace::SpanKind::kServer;
   g_telemetry_connection_span = esp_opentelemetry_tracer()->StartSpan(
-      "ws.telemetry.connection",
-      {{"ws.url", "/telemetry"},
-       {"network.protocol.name", "websocket"}},
+      "ws.telemetry.connection", {{"ws.url", "/telemetry"}, {"network.protocol.name", "websocket"}},
       tel_opts);
   httpd_req_t* copy = NULL;
   esp_err_t ret = httpd_req_async_handler_begin(req, &copy);
@@ -408,7 +402,7 @@ static esp_err_t telemetry_handle_handshake(httpd_req_t *req) {
   return ESP_OK;
 }
 
-static esp_err_t telemetry_handle_websocket_frame(httpd_req_t *req) {
+static esp_err_t telemetry_handle_websocket_frame(httpd_req_t* req) {
   esp_err_t ret = ESP_OK;
 
   httpd_ws_frame_t ws_pkt = {};
@@ -419,9 +413,9 @@ static esp_err_t telemetry_handle_websocket_frame(httpd_req_t *req) {
     return ret;
   }
 
-  unsigned char *buf = NULL;
+  unsigned char* buf = NULL;
   if (ws_pkt.len > 0) {
-    buf = (unsigned char *)malloc(ws_pkt.len);
+    buf = (unsigned char*)malloc(ws_pkt.len);
   }
 
   ws_pkt.payload = buf;
@@ -439,8 +433,8 @@ static esp_err_t telemetry_handle_websocket_frame(httpd_req_t *req) {
     } else if (ws_pkt.type == HTTPD_WS_TYPE_CLOSE) {
       ESP_LOGI(TAG, "Got a WS CLOSE frame, Replying CLOSE");
       if (g_telemetry_connection_span) {
-        g_telemetry_connection_span->SetAttribute(
-            "ws.close.code", static_cast<int64_t>(ws_pkt.len));
+        g_telemetry_connection_span->SetAttribute("ws.close.code",
+                                                  static_cast<int64_t>(ws_pkt.len));
       }
       ws_pkt.len = 0;
       ws_pkt.payload = NULL;
@@ -464,8 +458,7 @@ static esp_err_t telemetry_handle_websocket_frame(httpd_req_t *req) {
   return ret;
 }
 
-static esp_err_t telemetry_get_handler(httpd_req_t *req)
-{
+static esp_err_t telemetry_get_handler(httpd_req_t* req) {
   if (g_server_task_handle == NULL) {
     g_server_task_handle = xTaskGetCurrentTaskHandle();
   }
@@ -507,7 +500,8 @@ void ws_telemetry_task(void* p) {
       ESP_LOGI(TAG, "Telemetry stopped");
       if (g_telemetry_connection_span) {
         g_telemetry_connection_span->End();
-        g_telemetry_connection_span = opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>{};
+        g_telemetry_connection_span =
+            opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>{};
       }
       continue;
     }
@@ -524,7 +518,8 @@ void ws_telemetry_task(void* p) {
       ESP_LOGI(TAG, "Telemetry stopped");
       if (g_telemetry_connection_span) {
         g_telemetry_connection_span->End();
-        g_telemetry_connection_span = opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>{};
+        g_telemetry_connection_span =
+            opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>{};
       }
       continue;
     }
@@ -534,12 +529,11 @@ void ws_telemetry_task(void* p) {
     opentelemetry::trace::StartSpanOptions send_opts;
     send_opts.kind = opentelemetry::trace::SpanKind::kProducer;
     send_opts.parent = g_telemetry_connection_span->GetContext();
-    auto send_span = esp_opentelemetry_tracer()->StartSpan(
-        "ws.telemetry.send",
-        {{"ws.url", "/telemetry"},
-         {"network.protocol.name", "websocket"},
-         {"ws.message.type", "telemetry"}},
-        send_opts);
+    auto send_span = esp_opentelemetry_tracer()->StartSpan("ws.telemetry.send",
+                                                           {{"ws.url", "/telemetry"},
+                                                            {"network.protocol.name", "websocket"},
+                                                            {"ws.message.type", "telemetry"}},
+                                                           send_opts);
     auto send_scope = opentelemetry::trace::Scope(send_span);
     tracing_inject(*packet_json);
 
@@ -565,7 +559,8 @@ void ws_telemetry_task(void* p) {
       telemetry_stop();
       if (g_telemetry_connection_span) {
         g_telemetry_connection_span->End();
-        g_telemetry_connection_span = opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>{};
+        g_telemetry_connection_span =
+            opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>{};
       }
       // Do NOT notify g_server_task_handle here: no CLOSE handler is waiting,
       // and a spurious notification would be consumed as a stale one by the next
@@ -582,69 +577,66 @@ void ws_telemetry_task(void* p) {
 }
 
 static const httpd_uri_t telemetry = {
-    .uri       = "/telemetry",
-    .method    = HTTP_GET,
-    .handler   = telemetry_get_handler,
-    .user_ctx  = NULL,
+    .uri = "/telemetry",
+    .method = HTTP_GET,
+    .handler = telemetry_get_handler,
+    .user_ctx = NULL,
     .is_websocket = true,
     .handle_ws_control_frames = true,
     .supported_subprotocol = NULL,
     .ws_post_handshake_cb = telemetry_handle_handshake,
 };
 
-static httpd_handle_t start_web_server()
-{
-    httpd_config_t config = HTTPD_DEFAULT_CONFIG();
-    config.lru_purge_enable = true;
-    config.max_open_sockets = 3;
-    // 8 KB is insufficient for root_get_handler with tracing_extract + StartSpan.
-    config.stack_size = 16384;
+static httpd_handle_t start_web_server() {
+  httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+  config.lru_purge_enable = true;
+  config.max_open_sockets = 3;
+  // 8 KB is insufficient for root_get_handler with tracing_extract + StartSpan.
+  config.stack_size = 16384;
 
-    ESP_LOGI(TAG, "Starting server on port: '%d'", config.server_port);
-    esp_err_t err = httpd_start(&server, &config);
-    if (err == ESP_OK) {
-        ESP_LOGI(TAG, "Registering URI handlers");
-        httpd_register_uri_handler(server, &root);
-        httpd_register_uri_handler(server, &stream);
-        httpd_register_uri_handler(server, &telemetry);
-        return server;
-    }
+  ESP_LOGI(TAG, "Starting server on port: '%d'", config.server_port);
+  esp_err_t err = httpd_start(&server, &config);
+  if (err == ESP_OK) {
+    ESP_LOGI(TAG, "Registering URI handlers");
+    httpd_register_uri_handler(server, &root);
+    httpd_register_uri_handler(server, &stream);
+    httpd_register_uri_handler(server, &telemetry);
+    return server;
+  }
 
-    ESP_LOGE(TAG, "Error starting server: %s", esp_err_to_name(err));
-    return NULL;
+  ESP_LOGE(TAG, "Error starting server: %s", esp_err_to_name(err));
+  return NULL;
 }
 
-static esp_err_t stop_web_server(httpd_handle_t server)
-{
-    g_server_task_handle = NULL;
-    return httpd_stop(server);
+static esp_err_t stop_web_server(httpd_handle_t server) {
+  g_server_task_handle = NULL;
+  return httpd_stop(server);
 }
 
-static void web_server_handler_on_got_ip(void* arg, esp_event_base_t event_base,
-                            int32_t event_id, void* event_data)
-{
-    httpd_handle_t* server = (httpd_handle_t*) arg;
-    if (*server == NULL) {
-        ESP_LOGI(TAG, "Starting web server");
-        *server = start_web_server();
-    }
+static void web_server_handler_on_got_ip(void* arg, esp_event_base_t event_base, int32_t event_id,
+                                         void* event_data) {
+  httpd_handle_t* server = (httpd_handle_t*)arg;
+  if (*server == NULL) {
+    ESP_LOGI(TAG, "Starting web server");
+    *server = start_web_server();
+  }
 }
 
 static void web_server_handler_on_wifi_disconnect(void* arg, esp_event_base_t event_base,
-                               int32_t event_id, void* event_data)
-{
-    httpd_handle_t* server = (httpd_handle_t*) arg;
-    if (*server) {
-        ESP_LOGI(TAG, "Stopping web server");
-        if (stop_web_server(*server) == ESP_OK) {
-            *server = NULL;
-        } else {
-            ESP_LOGE(TAG, "Failed to stop http server");
-        }
+                                                  int32_t event_id, void* event_data) {
+  httpd_handle_t* server = (httpd_handle_t*)arg;
+  if (*server) {
+    ESP_LOGI(TAG, "Stopping web server");
+    if (stop_web_server(*server) == ESP_OK) {
+      *server = NULL;
+    } else {
+      ESP_LOGE(TAG, "Failed to stop http server");
     }
+  }
 }
 
-void web_server_setup(QueueHandle_t frame_queue, QueueHandle_t command_queue, QueueHandle_t telemetry_queue) {
+void web_server_setup(QueueHandle_t frame_queue, QueueHandle_t command_queue,
+                      QueueHandle_t telemetry_queue) {
   g_frame_queue = frame_queue;
   g_command_queue = command_queue;
   g_telemetry_packet_queue = telemetry_queue;
@@ -655,33 +647,31 @@ void web_server_setup(QueueHandle_t frame_queue, QueueHandle_t command_queue, Qu
   {
     // Allocate ws_stream_task stack from PSRAM: base64 encoding of VGA JPEG frames plus
     // cJSON serialization and OTel span creation exhaust an 8KB DRAM stack.
-    StackType_t *stream_stack = static_cast<StackType_t*>(
-        heap_caps_malloc(32768, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
-    StaticTask_t *stream_tcb = static_cast<StaticTask_t*>(
+    StackType_t* stream_stack =
+        static_cast<StackType_t*>(heap_caps_malloc(32768, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+    StaticTask_t* stream_tcb = static_cast<StaticTask_t*>(
         heap_caps_malloc(sizeof(StaticTask_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
     if (!stream_stack || !stream_tcb) {
       ESP_LOGE(TAG, "xTaskCreate(ws_stream_task) failed - no PSRAM");
       return;
     }
-    g_stream_task_handle = xTaskCreateStaticPinnedToCore(
-        ws_stream_task, "ws_stream_task",
-        32768 / sizeof(StackType_t), nullptr, 1,
-        stream_stack, stream_tcb, tskNO_AFFINITY);
+    g_stream_task_handle =
+        xTaskCreateStaticPinnedToCore(ws_stream_task, "ws_stream_task", 32768 / sizeof(StackType_t),
+                                      nullptr, 1, stream_stack, stream_tcb, tskNO_AFFINITY);
   }
   {
     // Allocate ws_telemetry_task stack from PSRAM to avoid exhausting internal DRAM.
-    StackType_t *tel_stack = static_cast<StackType_t*>(
-        heap_caps_malloc(32768, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
-    StaticTask_t *tel_tcb = static_cast<StaticTask_t*>(
+    StackType_t* tel_stack =
+        static_cast<StackType_t*>(heap_caps_malloc(32768, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+    StaticTask_t* tel_tcb = static_cast<StaticTask_t*>(
         heap_caps_malloc(sizeof(StaticTask_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
     if (!tel_stack || !tel_tcb) {
       ESP_LOGE(TAG, "xTaskCreate(ws_telemetry_task) failed - no PSRAM");
       return;
     }
-    g_telemetry_task_handle = xTaskCreateStaticPinnedToCore(
-        ws_telemetry_task, "ws_telemetry_task",
-        32768 / sizeof(StackType_t), nullptr, 1,
-        tel_stack, tel_tcb, tskNO_AFFINITY);
+    g_telemetry_task_handle = xTaskCreateStaticPinnedToCore(ws_telemetry_task, "ws_telemetry_task",
+                                                            32768 / sizeof(StackType_t), nullptr, 1,
+                                                            tel_stack, tel_tcb, tskNO_AFFINITY);
   }
 
   // Start the server before registering event handlers to avoid a race where
@@ -689,7 +679,8 @@ void web_server_setup(QueueHandle_t frame_queue, QueueHandle_t command_queue, Qu
   // instance while this function is still about to call start_web_server().
   server = start_web_server();
 
-  ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, &web_server_handler_on_got_ip, &server));
-  ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_STA_DISCONNECTED, &web_server_handler_on_wifi_disconnect, &server));
+  ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP,
+                                             &web_server_handler_on_got_ip, &server));
+  ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_STA_DISCONNECTED,
+                                             &web_server_handler_on_wifi_disconnect, &server));
 }
-

--- a/car/components/web_server/web_server_metrics.cpp
+++ b/car/components/web_server/web_server_metrics.cpp
@@ -15,15 +15,15 @@ static opentelemetry::nostd::shared_ptr<metrics_api::Counter<uint64_t>> s_frames
 
 void web_server_metrics_setup() {
 #ifdef CONFIG_ESP_OPENTELEMETRY_METRICS_ENABLED
-    auto meter = metrics_api::Provider::GetMeterProvider()->GetMeter(
-        CONFIG_ESP_OPENTELEMETRY_SERVICE_NAME, "1.0.0");
-    s_frames_sent = meter->CreateUInt64Counter(
-        "dust_mite.frames_sent", "Camera frames sent to client", "{frame}");
+  auto meter = metrics_api::Provider::GetMeterProvider()->GetMeter(
+      CONFIG_ESP_OPENTELEMETRY_SERVICE_NAME, "1.0.0");
+  s_frames_sent = meter->CreateUInt64Counter("dust_mite.frames_sent",
+                                             "Camera frames sent to client", "{frame}");
 #endif
 }
 
 void web_server_metrics_update() {
 #ifdef CONFIG_ESP_OPENTELEMETRY_METRICS_ENABLED
-    if (s_frames_sent) s_frames_sent->Add(1);
+  if (s_frames_sent) s_frames_sent->Add(1);
 #endif
 }

--- a/car/components/wifi/wifi.cpp
+++ b/car/components/wifi/wifi.cpp
@@ -20,9 +20,8 @@ static EventGroupHandle_t s_wifi_events;
 #define WIFI_PASSWORD "<PASSWORD>"
 #endif
 
-static void wifi_event_handler(void* arg, esp_event_base_t event_base,
-                               int32_t event_id, void* event_data)
-{
+static void wifi_event_handler(void* arg, esp_event_base_t event_base, int32_t event_id,
+                               void* event_data) {
   if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
     esp_wifi_connect();
   } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
@@ -37,8 +36,7 @@ void wifi_wait_for_ip() {
   xEventGroupWaitBits(s_wifi_events, WIFI_IP_READY_BIT, pdFALSE, pdFALSE, portMAX_DELAY);
 }
 
-void wifi_setup()
-{
+void wifi_setup() {
   s_wifi_events = xEventGroupCreate();
   ESP_ERROR_CHECK(nvs_flash_init());
   ESP_ERROR_CHECK(esp_netif_init());
@@ -48,8 +46,10 @@ void wifi_setup()
   wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
   ESP_ERROR_CHECK(esp_wifi_init(&cfg));
 
-  ESP_ERROR_CHECK(esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &wifi_event_handler, NULL, NULL));
-  ESP_ERROR_CHECK(esp_event_handler_instance_register(IP_EVENT, IP_EVENT_STA_GOT_IP, &wifi_event_handler, NULL, NULL));
+  ESP_ERROR_CHECK(esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID,
+                                                      &wifi_event_handler, NULL, NULL));
+  ESP_ERROR_CHECK(esp_event_handler_instance_register(IP_EVENT, IP_EVENT_STA_GOT_IP,
+                                                      &wifi_event_handler, NULL, NULL));
 
   wifi_config_t wifi_config = {};
   strcpy((char*)wifi_config.sta.ssid, WIFI_SSID);

--- a/car/main/main.cpp
+++ b/car/main/main.cpp
@@ -30,8 +30,7 @@ static i2c_master_bus_handle_t i2c_bus_init() {
   return bus;
 }
 
-extern "C" void app_main()
-{
+extern "C" void app_main() {
   QueueHandle_t command_queue = xQueueCreate(2, sizeof(command_packet_t));
   QueueHandle_t frame_queue = xQueueCreate(2, sizeof(camera_fb_t*));
   QueueHandle_t telemetry_queue = xQueueCreate(2, sizeof(telemetry_packet_t));

--- a/car/scripts/fix_checks.sh
+++ b/car/scripts/fix_checks.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Only reformats lines changed in the working tree/index, unlike
+# run_formatter.sh which checks the whole car/ tree.
+git-clang-format --style=file -- ":/car"

--- a/car/scripts/pre-commit.sh
+++ b/car/scripts/pre-commit.sh
@@ -1,1 +1,13 @@
 #!/bin/bash
+
+SCRIPTPATH=$(dirname "${BASH_SOURCE[0]}")
+
+OUTPUT=$("$SCRIPTPATH"/run_checks.sh 2>&1)
+STATUS=$?
+
+if [ $STATUS -ne 0 ]
+then
+    echo "$OUTPUT"
+fi
+
+exit $STATUS

--- a/car/scripts/run_checks.sh
+++ b/car/scripts/run_checks.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+SCRIPTPATH=$(dirname "$0")
+
+STATUS=0
+trap 'STATUS=1' ERR
+
+echo 'run_formatter.sh'
+$SCRIPTPATH/run_formatter.sh -n --Werror
+
+trap - ERR
+
+if [ $STATUS -ne 0 ]
+then
+    echo 'fix_checks.sh'
+    $SCRIPTPATH/fix_checks.sh
+fi
+
+exit $STATUS

--- a/car/scripts/run_formatter.sh
+++ b/car/scripts/run_formatter.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+SCRIPTPATH=$(dirname "$0")
+CAR_ROOT="$(cd "$SCRIPTPATH/.." && pwd)"
+
+mapfile -t FILES < <(find "$CAR_ROOT/main" "$CAR_ROOT/components" "$CAR_ROOT/test_apps" \
+    -path '*/managed_components/*' -prune -o \
+    -path '*/build/*' -prune -o \
+    -path '*/esp-opentelemetry-cpp/*' -prune -o \
+    -path '*/DFRobot_AXP313A/*' -prune -o \
+    -type f \( -name '*.cpp' -o -name '*.hpp' -o -name '*.h' -o -name '*.c' \) -print | sort)
+
+clang-format --style=file "$@" "${FILES[@]}"

--- a/car/test_apps/integration/main/main.cpp
+++ b/car/test_apps/integration/main/main.cpp
@@ -10,38 +10,36 @@
 #include "tracing.hpp"
 #include "wifi.hpp"
 
-static const char *TAG = "integration_test";
+static const char* TAG = "integration_test";
 
-static i2c_master_bus_handle_t i2c_bus_init()
-{
-    i2c_master_bus_config_t bus_cfg = {};
-    bus_cfg.i2c_port = I2C_NUM_0;
-    bus_cfg.sda_io_num = GPIO_NUM_1;
-    bus_cfg.scl_io_num = GPIO_NUM_2;
-    bus_cfg.clk_source = I2C_CLK_SRC_DEFAULT;
-    bus_cfg.glitch_ignore_cnt = 7;
-    bus_cfg.flags.enable_internal_pullup = true;
-    i2c_master_bus_handle_t bus;
-    ESP_ERROR_CHECK(i2c_new_master_bus(&bus_cfg, &bus));
-    return bus;
+static i2c_master_bus_handle_t i2c_bus_init() {
+  i2c_master_bus_config_t bus_cfg = {};
+  bus_cfg.i2c_port = I2C_NUM_0;
+  bus_cfg.sda_io_num = GPIO_NUM_1;
+  bus_cfg.scl_io_num = GPIO_NUM_2;
+  bus_cfg.clk_source = I2C_CLK_SRC_DEFAULT;
+  bus_cfg.glitch_ignore_cnt = 7;
+  bus_cfg.flags.enable_internal_pullup = true;
+  i2c_master_bus_handle_t bus;
+  ESP_ERROR_CHECK(i2c_new_master_bus(&bus_cfg, &bus));
+  return bus;
 }
 
-extern "C" void app_main()
-{
-    QueueHandle_t command_queue   = xQueueCreate(2, sizeof(command_packet_t));
-    QueueHandle_t frame_queue     = xQueueCreate(2, sizeof(camera_fb_t*));
-    QueueHandle_t telemetry_queue = xQueueCreate(2, sizeof(telemetry_packet_t));
+extern "C" void app_main() {
+  QueueHandle_t command_queue = xQueueCreate(2, sizeof(command_packet_t));
+  QueueHandle_t frame_queue = xQueueCreate(2, sizeof(camera_fb_t*));
+  QueueHandle_t telemetry_queue = xQueueCreate(2, sizeof(telemetry_packet_t));
 
-    i2c_master_bus_handle_t i2c_bus = i2c_bus_init();
+  i2c_master_bus_handle_t i2c_bus = i2c_bus_init();
 
-    motor_setup(command_queue);
-    wifi_setup();
-    wifi_wait_for_ip();
-    sync_time();
-    tracing_setup();
-    camera_setup(frame_queue, i2c_bus);
-    telemetry_setup(telemetry_queue, i2c_bus);
-    web_server_setup(frame_queue, command_queue, telemetry_queue);
+  motor_setup(command_queue);
+  wifi_setup();
+  wifi_wait_for_ip();
+  sync_time();
+  tracing_setup();
+  camera_setup(frame_queue, i2c_bus);
+  telemetry_setup(telemetry_queue, i2c_bus);
+  web_server_setup(frame_queue, command_queue, telemetry_queue);
 
-    ESP_LOGI(TAG, "integration test app ready");
+  ESP_LOGI(TAG, "integration test app ready");
 }


### PR DESCRIPTION
## Summary
- Adds `car/.clang-format` (Google-based style) and `car/scripts/run_formatter.sh`, run via a new `run-checks` CI job and wired into `car/scripts/pre-commit.sh`.
- Applies formatting across `car/main` and the dust-mite-owned components (purely whitespace/brace/pointer-alignment changes, no logic changes — verified the firmware still builds).
- Adds `car/scripts/fix_checks.sh` using `git-clang-format` so local fixes only touch staged/changed lines, matching the pre-commit hook.

Part of #87.

## Test plan
- [x] `./scripts/run_checks.sh` passes inside the C++ devcontainer
- [x] `idf.py build` succeeds after reformatting
- [x] `./scripts/pre-commit.sh` exits 0

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

https://claude.ai/code/session_01QwTBvENKGMczMo9x7nAMrg