### PR TITLE
Add cppcheck static analysis to car/ CI

### DIFF
--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -3,6 +3,7 @@ FROM espressif/idf:release-v6.0
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
     ccache \
+    cppcheck \
     curl \
     locales \
     protobuf-compiler

--- a/.github/workflows/cpp-car.yml
+++ b/.github/workflows/cpp-car.yml
@@ -177,8 +177,49 @@ jobs:
       run: ./scripts/run_clang_tidy.sh
       working-directory: car
 
+  cppcheck:
+    needs: build-docker
+    permissions:
+      contents: read
+      actions: read
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: ghcr.io/ltowarek/dust-mite-cpp-devcontainer
+      options: --user root
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Cache ccache
+      uses: actions/cache@v5
+      with:
+        path: ${{ github.workspace }}/.ccache
+        key: ccache-${{ runner.os }}-idf-cppcheck-${{ github.run_id }}
+        restore-keys: |
+          ccache-${{ runner.os }}-idf-cppcheck-
+
+    - name: Run cppcheck
+      env:
+        CCACHE_DIR: ${{ github.workspace }}/.ccache
+      run: |
+        source $IDF_PATH/export.sh
+        ./scripts/run_cppcheck.sh
+      working-directory: car
+
   ci-status-cpp-car:
-    needs: [build-docker, build, clang-format, clang-tidy]
+    needs: [build-docker, build, clang-format, clang-tidy, cppcheck]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -452,6 +452,15 @@ tolerates that link failure and only requires `compile_commands.json` to be gene
 `clang-tidy` CI job is blocking (part of `ci-status-cpp-car`); since `WarningsAsErrors` is
 empty, it only fails on a genuine clang-tidy tool error, not on findings.
 
+#### cppcheck
+
+`run_checks.sh` also runs `run_cppcheck.sh`, which performs static analysis with
+[cppcheck](https://cppcheck.sourceforge.io/) against `compile_commands.json` from a regular
+`idf.py build` (the production GCC toolchain, no special toolchain needed). Findings located in
+vendored dependencies or the ESP-IDF SDK itself, and a handful of confirmed cppcheck parser false
+positives on ESP-IDF's variadic `ESP_LOGx` macros, are suppressed in
+[car/.cppcheck-suppressions](car/.cppcheck-suppressions) with reasoning.
+
 ### Car test types
 
 Test scope and execution environment are independent choices. Scope determines what is under test; environment determines where it runs.

--- a/car/.cppcheck-suppressions
+++ b/car/.cppcheck-suppressions
@@ -1,0 +1,11 @@
+# cppcheck suppressions for car/, one per line: <id>:<path-glob>
+# See https://cppcheck.sourceforge.io/manual.html#suppressions
+
+# Findings transitively reported on vendored/SDK headers included by owned
+# sources; not actionable from owned code.
+*:*/esp-opentelemetry-cpp/*
+*:/opt/esp/idf/*
+
+# cppcheck's bundled parser can't resolve ESP-IDF's variadic ESP_LOGx macros
+# (esp_log.h). False positives are suppressed inline (cppcheck-suppress
+# comments) right above each affected call, not listed here.

--- a/car/components/camera/camera.cpp
+++ b/car/components/camera/camera.cpp
@@ -73,6 +73,7 @@ static QueueHandle_t g_frame_queue = NULL;
 static TaskHandle_t g_camera_task_handle = NULL;
 
 void camera_task(void* p) {
+  // cppcheck-suppress syntaxError ; cppcheck's parser can't resolve ESP-IDF's variadic ESP_LOGx macros
   ESP_LOGI(TAG, "Starting camera task");
   camera_fb_t* frame = NULL;
   bool started = false;

--- a/car/components/motor/motor.cpp
+++ b/car/components/motor/motor.cpp
@@ -44,6 +44,7 @@ void command_task(void* p) {
   command_packet_t packet = {0, 0};
   while (true) {
     if (xQueueReceive(g_command_queue, &packet, portMAX_DELAY) != pdPASS) {
+      // cppcheck-suppress syntaxError ; cppcheck's parser can't resolve ESP-IDF's variadic ESP_LOGx macros
       ESP_LOGE(TAG, "xQueueReceive failed");
       return;
     }

--- a/car/components/telemetry/telemetry.cpp
+++ b/car/components/telemetry/telemetry.cpp
@@ -56,6 +56,7 @@ static i2c_master_dev_handle_t g_imu_g_dev = NULL;
 #define URM_TRIG_PIN GPIO_NUM_16
 
 void sync_time() {
+  // cppcheck-suppress syntaxError ; cppcheck's parser can't resolve ESP-IDF's variadic ESP_LOGx macros
   ESP_LOGI(TAG, "Initializing SNTP");
   esp_sntp_config_t config = ESP_NETIF_SNTP_DEFAULT_CONFIG("pool.ntp.org");
   esp_netif_sntp_init(&config);

--- a/car/components/web_server/command_parser.cpp
+++ b/car/components/web_server/command_parser.cpp
@@ -6,8 +6,8 @@ bool parse_command_packet(const char* json, command_packet_t* out) {
   if (!json || !out) return false;
   cJSON* root = cJSON_Parse(json);
   if (!root) return false;
-  cJSON* cmd_obj = cJSON_GetObjectItem(root, "command");
-  cJSON* val_obj = cJSON_GetObjectItem(root, "value");
+  const cJSON* cmd_obj = cJSON_GetObjectItem(root, "command");
+  const cJSON* val_obj = cJSON_GetObjectItem(root, "value");
   out->command = cJSON_IsNumber(cmd_obj) ? (char)cJSON_GetNumberValue(cmd_obj) : 0;
   out->value = cJSON_IsNumber(val_obj) ? (int)cJSON_GetNumberValue(val_obj) : 0;
   cJSON_Delete(root);

--- a/car/components/wifi/wifi.cpp
+++ b/car/components/wifi/wifi.cpp
@@ -25,6 +25,7 @@ static void wifi_event_handler(void* arg, esp_event_base_t event_base, int32_t e
   if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
     esp_wifi_connect();
   } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+    // cppcheck-suppress syntaxError ; cppcheck's parser can't resolve ESP-IDF's variadic ESP_LOGx macros
     ESP_LOGI(TAG, "retrying connection to AP");
     esp_wifi_connect();
   } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {

--- a/car/scripts/run_checks.sh
+++ b/car/scripts/run_checks.sh
@@ -23,4 +23,11 @@ $SCRIPTPATH/run_clang_tidy.sh
 
 trap - ERR
 
+trap 'STATUS=1' ERR
+
+echo 'run_cppcheck.sh'
+$SCRIPTPATH/run_cppcheck.sh
+
+trap - ERR
+
 exit $STATUS

--- a/car/scripts/run_cppcheck.sh
+++ b/car/scripts/run_cppcheck.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+SCRIPTPATH=$(dirname "$0")
+CAR_ROOT="$(cd "$SCRIPTPATH/.." && pwd)"
+
+SDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.all" idf.py -C "$CAR_ROOT" build > /dev/null
+
+cppcheck --project="$CAR_ROOT/build/compile_commands.json" \
+    --enable=warning,performance,portability,style \
+    --suppressions-list="$CAR_ROOT/.cppcheck-suppressions" \
+    --inline-suppr \
+    --error-exitcode=1 \
+    --quiet \
+    "$@" \
+    --file-filter="$CAR_ROOT/main/*" \
+    --file-filter="$CAR_ROOT/components/camera/*" \
+    --file-filter="$CAR_ROOT/components/motor/*" \
+    --file-filter="$CAR_ROOT/components/telemetry/*" \
+    --file-filter="$CAR_ROOT/components/tracing/*" \
+    --file-filter="$CAR_ROOT/components/web_server/*" \
+    --file-filter="$CAR_ROOT/components/wifi/*"


### PR DESCRIPTION
## Summary
- Adds `car/.cppcheck-suppressions` and `car/scripts/run_cppcheck.sh`, run via a new blocking `cppcheck` CI job (added to `ci-status-cpp-car`'s `needs`) and wired into `car/scripts/run_checks.sh`/`pre-commit.sh`.
- Runs against `compile_commands.json` from a regular `idf.py build` — the production GCC toolchain, no special toolchain detour needed (unlike clang-tidy).
- Suppresses findings transitively reported on vendored dependencies and the ESP-IDF SDK itself (`*:*/esp-opentelemetry-cpp/*`, `*:/opt/esp/idf/*`) — not actionable from owned code.
- Adds inline `// cppcheck-suppress syntaxError` comments (4 call sites) for a confirmed cppcheck parser limitation with ESP-IDF's variadic `ESP_LOGx` macros — verified these are false positives, not real syntax errors (the real GCC build already catches genuine syntax errors).
- Fixes the only two real findings: `cJSON_GetObjectItem(...)` results in `command_parser.cpp` can be `const cJSON *` (cJSON's own API already takes `const cJSON *`, so this is a no-op at the ABI level).

Part of #87.

## Test plan
- [x] `./scripts/run_cppcheck.sh` passes cleanly (exit 0) from a clean build
- [x] Production GCC build succeeds after the const-correctness fix

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

https://claude.ai/code/session_01QwTBvENKGMczMo9x7nAMrg